### PR TITLE
feat: trigger timers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /config.toml
 .envrc
+test.sqlite

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /target
 /config.toml
 .envrc
-test.sqlite
+data

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,6 +314,7 @@ dependencies = [
  "diesel",
  "diesel_migrations",
  "notify",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,4 @@ diesel_migrations = { version = "2.2.0", features = [
 uuid = { version = "1.10.0", features = ["v4"] }
 notify = "6.1.1"
 struson = { version = "0.5.0", features = ["experimental", "serde"] }
+regex = "1.10.6"

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ $ curl -H 'Authorization: Basic <base_64_encoded_login>' 'http://localhost:8080/
 - [ ] Add more webhooks
   - [ ] Generic JSON
 - [ ] Add more options
-  - [ ] Cleanup duration (currently 10 days)
+  - [x] Cleanup duration (currently 10 days)
   - [x] Jellyfin `metadataRefreshMode` currently set to `FullRefresh`
 - [x] Databases
   - [x] SQLite

--- a/default.toml
+++ b/default.toml
@@ -12,6 +12,7 @@ password = "password"
 check_path = false
 max_retries = 5
 default_timer_wait = 60
+cleanup_days = 10
 
 [triggers.manual]
 type = "manual"

--- a/default.toml
+++ b/default.toml
@@ -11,6 +11,7 @@ password = "password"
 [opts]
 check_path = false
 max_retries = 5
+default_timer_wait = 60
 
 [triggers.manual]
 type = "manual"

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,7 @@ async fn main() -> anyhow::Result<()> {
 
     run_db_migrations(&mut pool.get().expect("Failed to get connection"));
 
-    let manager = PulseManager::new(settings.clone(), pool.clone());
+    let manager = PulseManager::new(settings, pool.clone());
 
     let service_task = manager.start();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use routes::triggers::trigger_post;
 use routes::{index::hello, triggers::trigger_get};
 use service::manager::PulseManager;
 use tracing::info;
-use utils::conn::get_pool;
+use utils::conn::{get_conn, get_pool};
 use utils::settings::Settings;
 
 pub mod routes {
@@ -43,8 +43,10 @@ async fn main() -> anyhow::Result<()> {
     info!("💫 autopulse starting up...");
 
     let pool = get_pool(database_url)?;
+    let conn = &mut get_conn(&pool);
 
-    run_db_migrations(&mut pool.get().expect("Failed to get connection"));
+    run_db_migrations(conn);
+    conn.init()?;
 
     let manager = PulseManager::new(settings, pool.clone());
 

--- a/src/routes/stats.rs
+++ b/src/routes/stats.rs
@@ -4,7 +4,7 @@ use actix_web::{get, web::Data, HttpResponse, Responder, Result};
 use serde::Serialize;
 use tracing::error;
 
-use crate::service::{service::PulseService, service::Stats};
+use crate::service::{manager::PulseManager, manager::Stats};
 
 #[derive(Serialize)]
 struct StatsResponse {
@@ -13,9 +13,9 @@ struct StatsResponse {
 }
 
 #[get("/stats")]
-pub async fn stats(service: Data<PulseService>) -> Result<impl Responder> {
+pub async fn stats(manager: Data<PulseManager>) -> Result<impl Responder> {
     let start = Instant::now();
-    let stats = service.get_stats();
+    let stats = manager.get_stats();
     let elapsed = start.elapsed().as_micros() as f64 / 1000.0;
 
     if let Err(e) = stats {

--- a/src/routes/status.rs
+++ b/src/routes/status.rs
@@ -5,23 +5,19 @@ use actix_web::{
 };
 use actix_web_httpauth::extractors::basic::BasicAuth;
 
-use crate::{
-    service::service::PulseService,
-    utils::{check_auth::check_auth, settings::Settings},
-};
+use crate::{service::manager::PulseManager, utils::check_auth::check_auth};
 
 #[get("/status/{id}")]
 pub async fn status(
     id: Path<String>,
-    service: Data<PulseService>,
-    settings: Data<Settings>,
+    manager: Data<PulseManager>,
     auth: BasicAuth,
 ) -> Result<impl Responder> {
-    if !check_auth(&auth, &settings) {
+    if !check_auth(&auth, &manager.settings) {
         return Ok(HttpResponse::Unauthorized().body("Unauthorized"));
     }
 
-    let scan_ev = service.get_event(&id);
+    let scan_ev = manager.get_event(&id);
 
     Ok(HttpResponse::Ok().json(scan_ev))
 }

--- a/src/routes/triggers.rs
+++ b/src/routes/triggers.rs
@@ -131,7 +131,6 @@ pub async fn trigger_get(
             let mut file_path = query.path.clone();
 
             if let Some(rewrite) = rewrite {
-                println!("rewriting path {} with {:?}", file_path, rewrite);
                 file_path = rewrite_path(file_path, rewrite);
             }
 

--- a/src/routes/triggers.rs
+++ b/src/routes/triggers.rs
@@ -8,27 +8,22 @@ use tracing::debug;
 
 use crate::{
     db::models::{FoundStatus, NewScanEvent},
-    service::{service::PulseService, triggers::manual::ManualQueryParams, webhooks::EventType},
-    utils::{
-        check_auth::check_auth,
-        rewrite::rewrite_path,
-        settings::{Settings, Trigger},
-    },
+    service::{manager::PulseManager, triggers::manual::ManualQueryParams, webhooks::EventType},
+    utils::{check_auth::check_auth, rewrite::rewrite_path, settings::Trigger},
 };
 
 #[post("/triggers/{trigger}")]
 pub async fn trigger_post(
     trigger: Path<String>,
-    settings: Data<Settings>,
-    service: Data<PulseService>,
+    manager: Data<PulseManager>,
     auth: BasicAuth,
     body: Json<serde_json::Value>,
 ) -> Result<impl Responder> {
-    if !check_auth(&auth, &settings) {
+    if !check_auth(&auth, &manager.settings) {
         return Ok(HttpResponse::Unauthorized().body("Unauthorized"));
     }
 
-    let trigger_settings = settings.triggers.get(&trigger.to_string());
+    let trigger_settings = manager.settings.triggers.get(&trigger.to_string());
 
     if trigger_settings.is_none() {
         return Ok(HttpResponse::NotFound().body("Trigger not found"));
@@ -36,11 +31,11 @@ pub async fn trigger_post(
 
     let trigger_settings = trigger_settings.unwrap();
 
-    match &trigger_settings {
-        Trigger::Sonarr { rewrite }
-        | Trigger::Radarr { rewrite }
-        | Trigger::Lidarr { rewrite }
-        | Trigger::Readarr { rewrite } => {
+    match trigger_settings {
+        Trigger::Sonarr { rewrite, timer }
+        | Trigger::Radarr { rewrite, timer }
+        | Trigger::Lidarr { rewrite, timer }
+        | Trigger::Readarr { rewrite, timer } => {
             let paths = trigger_settings.paths(body.into_inner());
 
             if paths.is_err() {
@@ -69,14 +64,14 @@ pub async fn trigger_post(
                     ..Default::default()
                 };
 
-                let scan_event = service.add_event(&new_scan_event);
+                let scan_event = manager.add_event(&new_scan_event);
 
                 if let Ok(scan_event) = scan_event {
                     scan_events.push(scan_event);
                 }
             }
 
-            service
+            manager
                 .webhooks
                 .send(
                     EventType::New,
@@ -88,6 +83,8 @@ pub async fn trigger_post(
                         .collect::<Vec<String>>(),
                 )
                 .await;
+
+            timer.tick();
 
             debug!(
                 "added {} file{} from {} trigger",
@@ -112,15 +109,14 @@ pub async fn trigger_post(
 pub async fn trigger_get(
     req: HttpRequest,
     trigger: Path<String>,
-    settings: Data<Settings>,
-    service: Data<PulseService>,
+    manager: Data<PulseManager>,
     auth: BasicAuth,
 ) -> Result<impl Responder> {
-    if !check_auth(&auth, &settings) {
+    if !check_auth(&auth, &manager.settings) {
         return Ok(HttpResponse::Unauthorized().body("Unauthorized"));
     }
 
-    let trigger_settings = settings.triggers.get(&trigger.to_string());
+    let trigger_settings = manager.settings.triggers.get(&trigger.to_string());
 
     if trigger_settings.is_none() {
         return Ok(HttpResponse::NotFound().body("Trigger not found"));
@@ -129,12 +125,13 @@ pub async fn trigger_get(
     let trigger_settings = trigger_settings.unwrap();
 
     match &trigger_settings {
-        Trigger::Manual { rewrite } => {
+        Trigger::Manual { rewrite, timer } => {
             let query = Query::<ManualQueryParams>::from_query(req.query_string())?;
 
             let mut file_path = query.path.clone();
 
             if let Some(rewrite) = rewrite {
+                println!("rewriting path {} with {:?}", file_path, rewrite);
                 file_path = rewrite_path(file_path, rewrite);
             }
 
@@ -145,16 +142,18 @@ pub async fn trigger_get(
                 ..Default::default()
             };
 
-            let scan_event = service.add_event(&new_scan_event);
+            let scan_event = manager.add_event(&new_scan_event);
 
             if let Err(e) = scan_event {
                 return Ok(HttpResponse::InternalServerError().body(e.to_string()));
             }
 
-            service
+            manager
                 .webhooks
                 .send(EventType::New, Some(trigger.to_string()), &[file_path])
                 .await;
+
+            timer.tick();
 
             debug!("added 1 file from {} trigger", trigger);
 

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -1,5 +1,5 @@
+pub mod manager;
 pub mod runner;
-pub mod service;
 pub mod targets;
 pub mod triggers;
 pub mod webhooks;

--- a/src/service/targets/command.rs
+++ b/src/service/targets/command.rs
@@ -2,7 +2,7 @@ use crate::{db::models::ScanEvent, utils::settings::TargetProcess};
 use serde::Deserialize;
 use tracing::{debug, error};
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Deserialize)]
 pub struct Command {
     path: Option<String>,
     timeout: Option<u64>,

--- a/src/service/targets/emby.rs
+++ b/src/service/targets/emby.rs
@@ -9,7 +9,7 @@ use struson::{
 };
 use tracing::{debug, error};
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Deserialize)]
 pub struct Emby {
     pub url: String,
     pub token: String,
@@ -18,7 +18,7 @@ pub struct Emby {
     pub metadata_refresh_mode: EmbyMetadataRefreshMode,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum EmbyMetadataRefreshMode {
     None,
@@ -46,7 +46,7 @@ impl Default for EmbyMetadataRefreshMode {
     }
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Clone)]
 #[serde(rename_all = "PascalCase")]
 struct Library {
     #[allow(dead_code)]
@@ -56,20 +56,20 @@ struct Library {
     collection_type: Option<String>,
 }
 
-#[derive(Serialize, Clone, Debug)]
+#[derive(Serialize, Clone)]
 #[serde(rename_all = "PascalCase")]
 struct UpdateRequest {
     path: String,
     update_type: String,
 }
 
-#[derive(Serialize, Clone, Debug)]
+#[derive(Serialize, Clone)]
 #[serde(rename_all = "PascalCase")]
 struct ScanPayload {
     updates: Vec<UpdateRequest>,
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Clone)]
 #[serde(rename_all = "PascalCase")]
 struct Item {
     id: String,

--- a/src/service/targets/plex.rs
+++ b/src/service/targets/plex.rs
@@ -4,31 +4,31 @@ use tracing::error;
 
 use crate::{db::models::ScanEvent, utils::settings::TargetProcess};
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Clone)]
 pub struct Plex {
     pub url: String,
     pub token: String,
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Clone)]
 struct Location {
     path: String,
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Clone)]
 struct Library {
     key: String,
     #[serde(rename = "Location")]
     location: Vec<Location>,
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Clone)]
 #[serde(rename_all = "PascalCase")]
 struct MediaContainer {
     directory: Vec<Library>,
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Clone)]
 #[serde(rename_all = "PascalCase")]
 struct LibraryResponse {
     media_container: MediaContainer,

--- a/src/service/triggers/lidarr.rs
+++ b/src/service/triggers/lidarr.rs
@@ -2,13 +2,13 @@ use serde::Deserialize;
 
 use crate::utils::settings::TriggerRequest;
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TrackFile {
     path: String,
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Clone)]
 #[serde(tag = "eventType")]
 pub enum LidarrRequest {
     #[serde(rename = "Download")]

--- a/src/service/triggers/notify.rs
+++ b/src/service/triggers/notify.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tracing::error;
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Deserialize, Clone)]
 pub struct NotifyService {
     pub paths: Vec<String>,
     pub rewrite: Option<Rewrite>,

--- a/src/service/triggers/notify.rs
+++ b/src/service/triggers/notify.rs
@@ -1,4 +1,4 @@
-use crate::utils::{rewrite::rewrite_path, settings::Rewrite};
+use crate::utils::{rewrite::rewrite_path, settings::Rewrite, timer::Timer};
 use notify::{
     event::{ModifyKind, RenameMode},
     Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher,
@@ -14,6 +14,8 @@ pub struct NotifyService {
     pub rewrite: Option<Rewrite>,
     pub recursive: Option<bool>,
     // pub exclude: Option<Vec<String>>,
+    #[serde(skip)]
+    pub timer: Timer,
 }
 
 impl NotifyService {

--- a/src/service/triggers/radarr.rs
+++ b/src/service/triggers/radarr.rs
@@ -2,19 +2,19 @@ use serde::Deserialize;
 
 use crate::utils::{join_path::join_path, settings::TriggerRequest};
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct MovieFile {
     relative_path: String,
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Movie {
     folder_path: String,
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Clone)]
 #[serde(tag = "eventType")]
 pub enum RadarrRequest {
     #[serde(rename = "Download")]

--- a/src/service/triggers/readarr.rs
+++ b/src/service/triggers/readarr.rs
@@ -2,13 +2,13 @@ use serde::Deserialize;
 
 use crate::utils::settings::TriggerRequest;
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct BookFile {
     path: String,
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Clone)]
 #[serde(tag = "eventType")]
 pub enum ReadarrRequest {
     #[serde(rename = "Download")]

--- a/src/service/triggers/sonarr.rs
+++ b/src/service/triggers/sonarr.rs
@@ -2,25 +2,25 @@ use serde::Deserialize;
 
 use crate::utils::{join_path::join_path, settings::TriggerRequest};
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct EpisodeFile {
     pub relative_path: String,
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Series {
     path: String,
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RenamedEpisodeFile {
     previous_path: String,
     relative_path: String,
 }
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Clone)]
 #[serde(tag = "eventType")]
 pub enum SonarrRequest {
     #[serde(rename = "EpisodeFileDelete")]

--- a/src/service/webhooks/discord.rs
+++ b/src/service/webhooks/discord.rs
@@ -2,13 +2,13 @@ use serde::{Deserialize, Serialize};
 
 use super::EventType;
 
-#[derive(Serialize, Clone, Debug)]
+#[derive(Serialize, Clone)]
 pub struct DiscordEmbedField {
     pub name: String,
     pub value: String,
 }
 
-#[derive(Serialize, Clone, Debug)]
+#[derive(Serialize, Clone)]
 pub struct DiscordEmbed {
     pub color: i32,
     pub timestamp: String,
@@ -16,14 +16,14 @@ pub struct DiscordEmbed {
     pub title: String,
 }
 
-#[derive(Serialize, Clone, Debug)]
+#[derive(Serialize, Clone)]
 pub struct DiscordEmbedContent {
     pub username: String,
     pub avatar_url: String,
     pub embeds: Vec<DiscordEmbed>,
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Clone)]
 pub struct DiscordWebhook {
     pub url: String,
     pub avatar_url: Option<String>,

--- a/src/service/webhooks/mod.rs
+++ b/src/service/webhooks/mod.rs
@@ -9,11 +9,6 @@ use crate::utils::settings::{Settings, Webhook};
 pub mod discord;
 
 #[derive(Clone)]
-pub struct WebhookManager {
-    settings: Settings,
-}
-
-#[derive(Clone)]
 pub enum EventType {
     New,
     Found,
@@ -50,6 +45,11 @@ impl EventType {
         }
         .to_string()
     }
+}
+
+#[derive(Clone)]
+pub struct WebhookManager {
+    settings: Settings,
 }
 
 impl WebhookManager {

--- a/src/utils/conn.rs
+++ b/src/utils/conn.rs
@@ -1,7 +1,8 @@
 use crate::db::models::{NewScanEvent, ScanEvent};
 use anyhow::Context;
+use diesel::connection::SimpleConnection;
 use diesel::r2d2::{ConnectionManager, Pool, PooledConnection};
-use diesel::{Connection, QueryResult, RunQueryDsl};
+use diesel::{Connection, ConnectionError, QueryResult, RunQueryDsl};
 use diesel::{SaveChangesDsl, SelectableHelper};
 
 #[derive(diesel::MultiConnection)]
@@ -12,6 +13,24 @@ pub enum AnyConnection {
 }
 
 impl AnyConnection {
+    pub fn init(&mut self) -> anyhow::Result<()> {
+        match self {
+            Self::Sqlite(conn) => {
+                conn.batch_execute("
+                    PRAGMA journal_mode = WAL;          -- better write-concurrency
+                    PRAGMA synchronous = NORMAL;        -- fsync only in critical moments
+                    PRAGMA wal_autocheckpoint = 1000;   -- write WAL changes back every 1000 pages, for an in average 1MB WAL file. May affect readers if number is increased
+                    PRAGMA wal_checkpoint(TRUNCATE);    -- free some space by truncating possibly massive WAL files from the last run.
+                    PRAGMA busy_timeout = 250;          -- sleep if the database is busy
+                    PRAGMA foreign_keys = ON;           -- enforce foreign keys
+                ").map_err(ConnectionError::CouldntSetupConfiguration)?;
+            }
+            _ => {}
+        }
+
+        Ok(())
+    }
+
     pub fn save_changes(&mut self, ev: &mut ScanEvent) -> anyhow::Result<ScanEvent> {
         let ev = match self {
             Self::Postgresql(conn) => ev.save_changes::<ScanEvent>(conn),

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -4,3 +4,4 @@ pub mod conn;
 pub mod join_path;
 pub mod rewrite;
 pub mod settings;
+pub mod timer;

--- a/src/utils/rewrite.rs
+++ b/src/utils/rewrite.rs
@@ -1,9 +1,90 @@
 use super::settings::Rewrite;
+use regex::Regex;
 
-// TODO: Refactor to allow for regex rewrites
 pub fn rewrite_path(path: String, rewrite: &Rewrite) -> String {
-    let from = rewrite.from.clone();
-    let to = rewrite.to.clone();
+    let from = &rewrite.from;
+    let to = &rewrite.to;
 
-    path.replace(&from, &to)
+    let from_regex = Regex::new(from).expect("Invalid regex in 'from' field");
+    let result = from_regex.replace(&path, to as &str).to_string();
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rewrite_path_same() {
+        let path = "/testing/movie.mkv".to_string();
+        let rewrite = Rewrite {
+            from: "/testing".to_string(),
+            to: "/testing".to_string(),
+        };
+
+        let result = rewrite_path(path.clone(), &rewrite);
+
+        assert_eq!(result, path);
+    }
+
+    #[test]
+    fn test_rewrite_path() {
+        let path = "/testing/movie.mkv".to_string();
+        let rewrite = Rewrite {
+            from: "/testing".to_string(),
+            to: "/movies".to_string(),
+        };
+
+        let result = rewrite_path(path, &rewrite);
+
+        assert_eq!(result, "/movies/movie.mkv");
+    }
+
+    #[test]
+    fn test_rewrite_path_trailing() {
+        let path = "/testing/movie.mkv".to_string();
+        let rewrite = Rewrite {
+            from: "/testing/".to_string(),
+            to: "/movies/".to_string(),
+        };
+
+        let result = rewrite_path(path, &rewrite);
+
+        assert_eq!(result, "/movies/movie.mkv");
+    }
+
+    #[test]
+    fn test_rewrite_path_mismatch() {
+        let path = "/testing/movie.mkv".to_string();
+        let rewrite = Rewrite {
+            from: "/testing".to_string(),
+            to: "/movies/".to_string(),
+        };
+
+        let result_1 = rewrite_path(path.clone(), &rewrite);
+
+        let rewrite = Rewrite {
+            from: "/testing/".to_string(),
+            to: "/movies".to_string(),
+        };
+
+        let result_2 = rewrite_path(path, &rewrite);
+
+        assert_eq!(result_1, "/movies//movie.mkv");
+        assert_eq!(result_2, "/moviesmovie.mkv");
+    }
+
+    #[test]
+    fn test_rewrite_path_with_regex() {
+        let path = "/testing/movie123.mkv".to_string();
+        let rewrite = Rewrite {
+            from: "/testing/movie(\\d+)".to_string(),
+            to: "/movies/film$1".to_string(),
+        };
+
+        let result = rewrite_path(path, &rewrite);
+
+        assert_eq!(result, "/movies/film123.mkv");
+    }
 }

--- a/src/utils/settings.rs
+++ b/src/utils/settings.rs
@@ -36,6 +36,7 @@ pub struct Opts {
     pub check_path: bool,
     pub max_retries: i32,
     pub default_timer_wait: u64,
+    pub cleanup_days: u64,
 }
 
 #[derive(Deserialize, Clone, Debug)]

--- a/src/utils/settings.rs
+++ b/src/utils/settings.rs
@@ -35,6 +35,7 @@ pub struct Auth {
 pub struct Opts {
     pub check_path: bool,
     pub max_retries: i32,
+    pub default_timer_wait: u64,
 }
 
 #[derive(Deserialize, Clone, Debug)]

--- a/src/utils/timer.rs
+++ b/src/utils/timer.rs
@@ -5,15 +5,10 @@ use std::{
 
 use serde::Deserialize;
 
-use super::settings::Settings;
-
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Deserialize, Clone)]
 pub struct Timer {
     #[serde(skip)]
     last_tick: Arc<Mutex<chrono::DateTime<chrono::Utc>>>,
-
-    #[serde(skip)]
-    default: u64,
 
     wait: Option<u64>,
 }
@@ -29,7 +24,6 @@ impl Timer {
         Self {
             last_tick: Arc::new(Mutex::new(chrono::Utc::now())),
             wait: None,
-            default: Settings::get_settings().unwrap().opts.default_timer_wait,
         }
     }
 
@@ -38,8 +32,8 @@ impl Timer {
         *last_tick = chrono::Utc::now();
     }
 
-    pub fn can_tick(&self) -> bool {
-        let buffer_time = Duration::from_secs(self.wait.unwrap_or(self.default));
+    pub fn can_tick(&self, default: u64) -> bool {
+        let buffer_time = Duration::from_secs(self.wait.unwrap_or(default));
 
         *self.last_tick.lock().unwrap() + buffer_time < chrono::Utc::now()
     }

--- a/src/utils/timer.rs
+++ b/src/utils/timer.rs
@@ -1,0 +1,40 @@
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct Timer {
+    #[serde(skip)]
+    last_tick: Arc<Mutex<chrono::DateTime<chrono::Utc>>>,
+
+    wait: Option<u64>,
+}
+
+impl Default for Timer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Timer {
+    pub fn new() -> Self {
+        Self {
+            last_tick: Arc::new(Mutex::new(chrono::Utc::now())),
+            wait: None,
+        }
+    }
+
+    pub fn tick(&self) {
+        let mut last_tick = self.last_tick.lock().unwrap();
+        *last_tick = chrono::Utc::now();
+    }
+
+    pub fn can_tick(&self) -> bool {
+        let buffer_time = Duration::from_secs(self.wait.unwrap_or(10));
+
+        *self.last_tick.lock().unwrap() + buffer_time < chrono::Utc::now()
+    }
+}

--- a/src/utils/timer.rs
+++ b/src/utils/timer.rs
@@ -5,10 +5,15 @@ use std::{
 
 use serde::Deserialize;
 
+use super::settings::Settings;
+
 #[derive(Debug, Deserialize, Clone)]
 pub struct Timer {
     #[serde(skip)]
     last_tick: Arc<Mutex<chrono::DateTime<chrono::Utc>>>,
+
+    #[serde(skip)]
+    default: u64,
 
     wait: Option<u64>,
 }
@@ -24,6 +29,7 @@ impl Timer {
         Self {
             last_tick: Arc::new(Mutex::new(chrono::Utc::now())),
             wait: None,
+            default: Settings::get_settings().unwrap().opts.default_timer_wait,
         }
     }
 
@@ -33,7 +39,7 @@ impl Timer {
     }
 
     pub fn can_tick(&self) -> bool {
-        let buffer_time = Duration::from_secs(self.wait.unwrap_or(10));
+        let buffer_time = Duration::from_secs(self.wait.unwrap_or(self.default));
 
         *self.last_tick.lock().unwrap() + buffer_time < chrono::Utc::now()
     }


### PR DESCRIPTION
# Description

Adds a `Timer` instance to triggers and allows processing to be batched per-trigger as it resets the timer every time a file is added

```yaml
# Default timer wait time (default: 60s)
opts:
  default_timer_wait: 120 # In seconds

# Trigger timer wait time
triggers:
  my_sonarr:
    type: "sonarr"
    timer:
      wait: 5 # In seconds
    rewrite:
      from: "/downloads"
      to: "/tvshows"
```

Closes #4 

## Type of change

Please delete options that are not relevant.

- [ ] Bug (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (addition or change to documentation)
