### PR TITLE
fix: settings clone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,6 @@ WORKDIR /app
 RUN apt-get update -y && apt-get install -y ca-certificates libssl-dev libpq-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /usr/src/autopulse/target/release/autopulse /usr/local/bin/
-COPY default.toml default.toml
 
 EXPOSE 2875
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -42,6 +42,9 @@ COPY README.md README.md
 # Database support: postgres, sqlite
 ARG ENABLED_FEATURES="postgres,sqlite"
 
+# Add file to include
+ADD default.toml default.toml
+
 RUN cargo build --release --target x86_64-unknown-linux-musl --no-default-features --features ${ENABLED_FEATURES}
 
 FROM alpine AS runtime

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -54,7 +54,6 @@ WORKDIR /app
 # RUN addgroup -S user && adduser -S user -G user
 
 COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/autopulse /usr/local/bin/
-COPY default.toml default.toml
 
 # RUN chown -R user:user /app
 

--- a/src/db/conn.rs
+++ b/src/db/conn.rs
@@ -52,7 +52,7 @@ impl AnyConnection {
                 PRAGMA synchronous = NORMAL;        -- fsync only in critical moments
                 PRAGMA wal_autocheckpoint = 1000;   -- write WAL changes back every 1000 pages, for an in average 1MB WAL file. May affect readers if number is increased
                 PRAGMA wal_checkpoint(TRUNCATE);    -- free some space by truncating possibly massive WAL files from the last run.
-                PRAGMA busy_timeout = 250;          -- sleep if the database is busy
+                PRAGMA busy_timeout = 5000;         -- sleep if the database is busy
                 PRAGMA foreign_keys = ON;           -- enforce foreign keys
             ").map_err(ConnectionError::CouldntSetupConfiguration)?;
         }

--- a/src/service/targets/command.rs
+++ b/src/service/targets/command.rs
@@ -76,7 +76,7 @@ impl Command {
 }
 
 impl TargetProcess for Command {
-    async fn process(&mut self, evs: &[&ScanEvent]) -> anyhow::Result<Vec<String>> {
+    async fn process(&self, evs: &[&ScanEvent]) -> anyhow::Result<Vec<String>> {
         let mut succeded = Vec::new();
 
         for ev in evs {

--- a/src/service/targets/emby.rs
+++ b/src/service/targets/emby.rs
@@ -218,7 +218,7 @@ impl Emby {
 }
 
 impl TargetProcess for Emby {
-    async fn process<'a>(&mut self, evs: &[&'a ScanEvent]) -> anyhow::Result<Vec<String>> {
+    async fn process<'a>(&self, evs: &[&'a ScanEvent]) -> anyhow::Result<Vec<String>> {
         let libraries = self.libraries().await?;
 
         let mut succeded = Vec::new();

--- a/src/service/targets/fileflows.rs
+++ b/src/service/targets/fileflows.rs
@@ -39,7 +39,7 @@ impl FileFlows {
 }
 
 impl TargetProcess for FileFlows {
-    async fn process<'a>(&mut self, evs: &[&'a ScanEvent]) -> anyhow::Result<Vec<String>> {
+    async fn process<'a>(&self, evs: &[&'a ScanEvent]) -> anyhow::Result<Vec<String>> {
         let mut succeeded = Vec::new();
 
         for ev in evs {

--- a/src/service/targets/plex.rs
+++ b/src/service/targets/plex.rs
@@ -107,7 +107,7 @@ impl Plex {
 }
 
 impl TargetProcess for Plex {
-    async fn process<'a>(&mut self, evs: &[&'a ScanEvent]) -> anyhow::Result<Vec<String>> {
+    async fn process<'a>(&self, evs: &[&'a ScanEvent]) -> anyhow::Result<Vec<String>> {
         let libraries = self.libraries().await?;
 
         let mut succeeded = Vec::new();

--- a/src/service/targets/tdarr.rs
+++ b/src/service/targets/tdarr.rs
@@ -80,7 +80,7 @@ impl Tdarr {
 }
 
 impl TargetProcess for Tdarr {
-    async fn process<'a>(&mut self, evs: &[&'a ScanEvent]) -> anyhow::Result<Vec<String>> {
+    async fn process<'a>(&self, evs: &[&'a ScanEvent]) -> anyhow::Result<Vec<String>> {
         let mut succeeded = Vec::new();
 
         self.scan(evs).await?;

--- a/src/service/triggers/lidarr.rs
+++ b/src/service/triggers/lidarr.rs
@@ -5,7 +5,6 @@ use crate::utils::{
 use serde::Deserialize;
 
 #[derive(Deserialize, Clone)]
-
 pub struct Lidarr {
     /// Rewrite path
     pub rewrite: Option<Rewrite>,

--- a/src/service/triggers/manual.rs
+++ b/src/service/triggers/manual.rs
@@ -2,7 +2,6 @@ use crate::utils::{settings::Rewrite, timer::Timer};
 use serde::Deserialize;
 
 #[derive(Deserialize, Clone)]
-
 pub struct Manual {
     /// Rewrite path
     pub rewrite: Option<Rewrite>,

--- a/src/service/triggers/radarr.rs
+++ b/src/service/triggers/radarr.rs
@@ -4,7 +4,6 @@ use crate::utils::{
 use serde::Deserialize;
 
 #[derive(Deserialize, Clone)]
-
 pub struct Radarr {
     /// Rewrite path
     pub rewrite: Option<Rewrite>,

--- a/src/service/triggers/readarr.rs
+++ b/src/service/triggers/readarr.rs
@@ -5,7 +5,6 @@ use crate::utils::{
 use serde::Deserialize;
 
 #[derive(Deserialize, Clone)]
-
 pub struct Readarr {
     /// Rewrite path
     pub rewrite: Option<Rewrite>,

--- a/src/service/triggers/sonarr.rs
+++ b/src/service/triggers/sonarr.rs
@@ -6,7 +6,6 @@ use crate::utils::{
 use serde::Deserialize;
 
 #[derive(Deserialize, Clone)]
-
 pub struct Sonarr {
     /// Rewrite path
     pub rewrite: Option<Rewrite>,

--- a/src/service/webhooks/manager.rs
+++ b/src/service/webhooks/manager.rs
@@ -54,12 +54,12 @@ impl EventType {
 
 #[derive(Clone)]
 pub struct WebhookManager {
-    settings: Settings,
+    settings: Arc<Settings>,
     queue: Arc<RwLock<WebhookQueue>>,
 }
 
 impl WebhookManager {
-    pub fn new(settings: Settings) -> Self {
+    pub fn new(settings: Arc<Settings>) -> Self {
         Self {
             settings,
             queue: Arc::new(RwLock::new(HashMap::new())),

--- a/src/utils/settings.rs
+++ b/src/utils/settings.rs
@@ -13,7 +13,7 @@ use crate::{
         webhooks::{discord::DiscordWebhook, WebhookBatch},
     },
 };
-use config::{Config, File};
+use config::{Config, FileFormat};
 use serde::Deserialize;
 use std::collections::HashMap;
 
@@ -99,7 +99,10 @@ pub struct Settings {
 impl Settings {
     pub fn get_settings(optional_config_file: Option<String>) -> anyhow::Result<Self> {
         let mut settings = Config::builder()
-            .add_source(File::with_name("default.toml"))
+            .add_source(config::File::from_str(
+                include_str!("../../default.toml"),
+                FileFormat::Toml,
+            ))
             .add_source(config::File::with_name("config").required(false))
             .add_source(config::Environment::with_prefix("AUTOPULSE").separator("__"));
 

--- a/src/utils/settings.rs
+++ b/src/utils/settings.rs
@@ -229,7 +229,7 @@ impl Webhook {
 
 pub trait TargetProcess {
     fn process<'a>(
-        &mut self,
+        &self,
         evs: &[&'a ScanEvent],
     ) -> impl std::future::Future<Output = anyhow::Result<Vec<String>>> + Send;
 }
@@ -256,7 +256,7 @@ pub enum Target {
 }
 
 impl Target {
-    pub async fn process(&mut self, evs: &[&ScanEvent]) -> anyhow::Result<Vec<String>> {
+    pub async fn process(&self, evs: &[&ScanEvent]) -> anyhow::Result<Vec<String>> {
         match self {
             Self::Plex(p) => p.process(evs).await,
             Self::Jellyfin(j) => j.process(evs).await,

--- a/src/utils/timer.rs
+++ b/src/utils/timer.rs
@@ -1,9 +1,8 @@
+use serde::Deserialize;
 use std::{
     sync::{Arc, Mutex},
     time::Duration,
 };
-
-use serde::Deserialize;
 
 #[derive(Deserialize, Clone)]
 pub struct Timer {


### PR DESCRIPTION
# Description

Ref #27
Possibly ref #34 

`Settings` was being cloned and then also using a RwLock wasn't required due to the timer rewrite

## Type of change

Please delete options that are not relevant.

- [x] Bug (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (addition or change to documentation)
