### PR TITLE
Only make default.toml mandatory if no custom configuration file location is provided.

### DIFF
--- a/src/utils/settings.rs
+++ b/src/utils/settings.rs
@@ -99,12 +99,13 @@ pub struct Settings {
 impl Settings {
     pub fn get_settings(optional_config_file: Option<String>) -> anyhow::Result<Self> {
         let mut settings = Config::builder()
-            .add_source(File::with_name("default.toml"))
             .add_source(config::File::with_name("config").required(false))
             .add_source(config::Environment::with_prefix("AUTOPULSE").separator("__"));
 
         if let Some(file_loc) = optional_config_file {
             settings = settings.add_source(config::File::with_name(&file_loc));
+        } else {
+            settings = settings.add_source(File::with_name("default.toml"));
         }
 
         let settings = settings.build()?;


### PR DESCRIPTION
# Description

Since it is now possible to provide a configuration file location with the `-c` command line argument, `default.toml` should only be mandatory if no alternate configuration file location is provided

## Type of change

Please delete options that are not relevant.

- [x] Bug (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (addition or change to documentation)

<!-- 
Before you submit, consider this checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
-->
