### PR TITLE
feat(docker): use linuxserver base image

### DIFF
--- a/.github/workflows/continuous-delivery-docker.yml
+++ b/.github/workflows/continuous-delivery-docker.yml
@@ -140,7 +140,7 @@ jobs:
           fi
         id: tag
 
-      - name: Build binary
+      - name: Test binary
         uses: houseabsolute/actions-rust-cross@v0
         if: matrix.feature == 'full'
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,10 @@ COPY ./autopulse /bin
 ENV S6_AUTOPULSE_DIR=/etc/s6-overlay/s6-rc.d/svc-autopulse
 
 RUN mkdir -p $S6_AUTOPULSE_DIR && \
-    echo "#\!/usr/bin/with-contenv bash\n# shellcheck shell=bash\n/bin/autopulse" > $S6_AUTOPULSE_DIR/run && \
+    echo '#!/usr/bin/with-contenv bash' >> $S6_AUTOPULSE_DIR/run && \
+    echo '# shellcheck shell=bash' >> $S6_AUTOPULSE_DIR/run && \
+    echo '' >> $S6_AUTOPULSE_DIR/run && \
+    echo 'cd /app && /bin/autopulse' >> $S6_AUTOPULSE_DIR/run && \
     chmod +x $S6_AUTOPULSE_DIR/run && \
     echo "longrun" > $S6_AUTOPULSE_DIR/type && \
     echo "3" > $S6_AUTOPULSE_DIR/notification-fd && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,7 @@ RUN mkdir -p $S6_AUTOPULSE_DIR && \
     chmod +x $S6_AUTOPULSE_DIR/run && \
     echo "longrun" > $S6_AUTOPULSE_DIR/type && \
     echo "3" > $S6_AUTOPULSE_DIR/notification-fd && \
-    mkdir $S6_AUTOPULSE_DIR/dependencies.d/ && echo "" > $S6_AUTOPULSE_DIR/dependencies.d/init-services
+    mkdir $S6_AUTOPULSE_DIR/dependencies.d/ && \
+    echo "" > $S6_AUTOPULSE_DIR/dependencies.d/init-services && \
+    mkdir -p /etc/s6-overlay/s6-rc.d/user/contents.d && \
+    echo "" > /etc/s6-overlay/s6-rc.d/user/contents.d/svc-autopulse

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ WORKDIR /app
 
 COPY ./autopulse /usr/local/bin/
 
-CMD ["/usr/local/bin/autopulse"]
+CMD ["with-contenv", "/usr/local/bin/autopulse"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,11 @@ FROM --platform=$BUILDPLATFORM ghcr.io/linuxserver/baseimage-alpine:3.20 AS runt
 
 WORKDIR /app
 
-COPY ./autopulse /usr/local/bin/
+COPY ./autopulse /bin
 
-CMD ["with-contenv", "/usr/local/bin/autopulse"]
+ENV S6_AUTOPULSE_DIR=/etc/s6-overlay/s6-rc.d/svc-autopulse
+
+RUN mkdir -p $S6_AUTOPULSE_DIR
+RUN echo "#!/usr/bin/with-contenv sh\n# shellcheck shell=sh\n/bin/autopulse" > $S6_AUTOPULSE_DIR/run
+RUN chmod +x $S6_AUTOPULSE_DIR/run
+RUN echo "longrun" > $S6_AUTOPULSE_DIR/type

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM alpine AS runtime
+FROM --platform=$BUILDPLATFORM ghcr.io/linuxserver/baseimage-alpine:3.20 AS runtime
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,9 @@ COPY ./autopulse /bin
 
 ENV S6_AUTOPULSE_DIR=/etc/s6-overlay/s6-rc.d/svc-autopulse
 
-RUN mkdir -p $S6_AUTOPULSE_DIR
-RUN echo "#!/usr/bin/with-contenv sh\n# shellcheck shell=sh\n/bin/autopulse" > $S6_AUTOPULSE_DIR/run
-RUN chmod +x $S6_AUTOPULSE_DIR/run
-RUN echo "longrun" > $S6_AUTOPULSE_DIR/type
+RUN mkdir -p $S6_AUTOPULSE_DIR && \
+    echo "#!/usr/bin/with-contenv sh\n# shellcheck shell=sh\n/bin/autopulse" > $S6_AUTOPULSE_DIR/run && \
+    chmod +x $S6_AUTOPULSE_DIR/run && \
+    echo "longrun" > $S6_AUTOPULSE_DIR/type && \
+    echo "3" > $S6_AUTOPULSE_DIR/notification-fd && \
+    mkdir $S6_AUTOPULSE_DIR/dependencies.d/ && echo "" > $S6_AUTOPULSE_DIR/dependencies.d/init-services

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY ./autopulse /bin
 ENV S6_AUTOPULSE_DIR=/etc/s6-overlay/s6-rc.d/svc-autopulse
 
 RUN mkdir -p $S6_AUTOPULSE_DIR && \
-    echo "#!/usr/bin/with-contenv sh\n# shellcheck shell=sh\n/bin/autopulse" > $S6_AUTOPULSE_DIR/run && \
+    echo "#\!/usr/bin/with-contenv bash\n# shellcheck shell=bash\n/bin/autopulse" > $S6_AUTOPULSE_DIR/run && \
     chmod +x $S6_AUTOPULSE_DIR/run && \
     echo "longrun" > $S6_AUTOPULSE_DIR/type && \
     echo "3" > $S6_AUTOPULSE_DIR/notification-fd && \

--- a/example/docker-compose-sqlite.yml
+++ b/example/docker-compose-sqlite.yml
@@ -10,4 +10,7 @@ services:
       - ./data:/app/data
       - /etc/localtime:/etc/localtime:ro # for correct timezone in timestamps
     environment:
-       AUTOPULSE__APP__DATABASE_URL: sqlite://data/autopulse.db
+      AUTOPULSE__APP__DATABASE_URL: sqlite://data/autopulse.db
+      # PUID: 1000
+      # PGID: 1000
+      # TZ: America/New_York

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -14,7 +14,10 @@ services:
       - ./config.yaml:/app/config.yaml
       - /etc/localtime:/etc/localtime:ro # for correct timezone in timestamps
     environment:
-       AUTOPULSE__APP__DATABASE_URL: postgres://autopulse:autopulse@postgres/autopulse
+      AUTOPULSE__APP__DATABASE_URL: postgres://autopulse:autopulse@postgres/autopulse
+      # PUID: 1000
+      # PGID: 1000
+      # TZ: Europe/London
 
   # Optional self-hosted UI
   # ui:

--- a/src/db/conn.rs
+++ b/src/db/conn.rs
@@ -69,14 +69,15 @@ impl AnyConnection {
                 })?;
             }
 
-            std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o777)).with_context(
-                || {
-                    format!(
-                        "Failed to set permissions on database directory: {}",
-                        parent.display()
-                    )
-                },
-            )?;
+            if path.file_name().map(|x| x.to_str()) != Some(path.to_str()) {
+                std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o777))
+                    .with_context(|| {
+                        format!(
+                            "Failed to set permissions on database directory: {}",
+                            parent.display()
+                        )
+                    })?;
+            }
         }
 
         Ok(())


### PR DESCRIPTION
# Description

Uses `ghcr.io/linuxserver/baseimage-alpine:3.20` instead of `alpine` for uid/gid control

Ref #99 

## Type of change

<!-- Fill in the appropriate box like so: [x] -->

- [ ] Bug (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (addition or change to documentation)

<!-- 
Before you submit, consider this checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
-->
