### PR TITLE
fix(webhooks): retry allowance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,6 +340,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.85",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -369,6 +380,7 @@ dependencies = [
  "actix-web",
  "actix-web-httpauth",
  "anyhow",
+ "async-recursion",
  "base64 0.22.1",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,8 +86,12 @@ uuid = { version = "1.10.0", features = ["v4"] }
 notify = "7.0.0"
 
 # Other
-struson = { version = "0.5.0", features = ["experimental", "serde"] }
-regex = "1.10.6"
+struson = { version = "0.5.0", features = [
+    "experimental",
+    "serde",
+] } # Parse Jellyfin response as a stream
+regex = "1.10.6" # Rewrite using regex
+async-recursion = "1.1.1" # Retry requests for webhooks
 
 # Command-line arguments
 clap = { version = "4.5.18", features = ["derive"] }

--- a/src/service/webhooks/discord.rs
+++ b/src/service/webhooks/discord.rs
@@ -1,6 +1,7 @@
 use super::{EventType, WebhookBatch};
 use crate::utils::{get_timestamp::get_timestamp, sify::sify};
 use serde::{Deserialize, Serialize};
+use tracing::trace;
 
 #[derive(Serialize, Clone)]
 #[doc(hidden)]
@@ -112,7 +113,8 @@ impl DiscordWebhook {
         content
     }
 
-    pub async fn send(&self, batch: &WebhookBatch) -> anyhow::Result<()> {
+    #[async_recursion::async_recursion]
+    pub async fn send(&self, batch: &WebhookBatch, retries: u8) -> anyhow::Result<()> {
         let mut message_queue = vec![];
 
         for chunk in batch.chunks(10) {
@@ -130,7 +132,31 @@ impl DiscordWebhook {
                 .map_err(|e| anyhow::anyhow!(e))?;
 
             if !res.status().is_success() {
+                let reset = res.headers().get("X-RateLimit-Reset");
+
+                if let Some(reset) = reset {
+                    if retries == 0 {
+                        return Err(anyhow::anyhow!("failed to send webhook, retries exhausted"));
+                    }
+
+                    let reset = reset.to_str().unwrap_or_default();
+                    let reset = reset.parse::<i64>().unwrap_or_default();
+                    let now = chrono::Utc::now().timestamp();
+
+                    if reset > now {
+                        let wait = reset - now;
+
+                        trace!("rate limited, waiting for {} seconds", wait);
+
+                        tokio::time::sleep(tokio::time::Duration::from_secs(wait as u64)).await;
+
+                        self.send(&batch, retries - 1).await?;
+                        continue;
+                    }
+                }
+
                 let body = res.text().await.unwrap_or_else(|_| "no body".to_string());
+
                 return Err(anyhow::anyhow!("failed to send webhook: {}", body));
             }
         }

--- a/src/service/webhooks/discord.rs
+++ b/src/service/webhooks/discord.rs
@@ -150,7 +150,7 @@ impl DiscordWebhook {
 
                         tokio::time::sleep(tokio::time::Duration::from_secs(wait as u64)).await;
 
-                        self.send(&batch, retries - 1).await?;
+                        self.send(batch, retries - 1).await?;
                         continue;
                     }
                 }

--- a/src/settings/webhook.rs
+++ b/src/settings/webhook.rs
@@ -11,7 +11,7 @@ pub enum Webhook {
 impl Webhook {
     pub async fn send(&self, batch: &WebhookBatch) -> anyhow::Result<()> {
         match self {
-            Self::Discord(d) => d.send(batch).await,
+            Self::Discord(d) => d.send(batch, 3).await,
         }
     }
 }


### PR DESCRIPTION
# Description

Closes #105 

Use a retry strategy to abide by Discord's retry header.

### Future Steps

Migrate webhooks to a table, or perhaps a property on the ScanEvent, similar to targets

## Type of change

<!-- Fill in the appropriate box like so: [x] -->

- [x] Bug (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (addition or change to documentation)

<!-- 
Before you submit, consider this checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
-->
