### PR TITLE
feat(service): add support for anchor paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
 # direnv
-.direnv
 .envrc
+.direnv
 
 # Testing
-config.toml
+/config.*
 autopulse.log
 data
 /target

--- a/src/service/targets/autopulse.rs
+++ b/src/service/targets/autopulse.rs
@@ -56,7 +56,7 @@ impl Autopulse {
 }
 
 impl TargetProcess for Autopulse {
-    async fn process<'a>(&self, evs: &[&'a ScanEvent]) -> anyhow::Result<Vec<String>> {
+    async fn process(&self, evs: &[&ScanEvent]) -> anyhow::Result<Vec<String>> {
         let mut succeded = Vec::new();
 
         for ev in evs {

--- a/src/service/targets/emby.rs
+++ b/src/service/targets/emby.rs
@@ -285,7 +285,7 @@ impl Emby {
 }
 
 impl TargetProcess for Emby {
-    async fn process<'a>(&self, evs: &[&'a ScanEvent]) -> anyhow::Result<Vec<String>> {
+    async fn process(&self, evs: &[&ScanEvent]) -> anyhow::Result<Vec<String>> {
         let libraries = self.libraries().await?;
 
         let mut succeded = Vec::new();

--- a/src/service/targets/fileflows.rs
+++ b/src/service/targets/fileflows.rs
@@ -39,7 +39,7 @@ impl FileFlows {
 }
 
 impl TargetProcess for FileFlows {
-    async fn process<'a>(&self, evs: &[&'a ScanEvent]) -> anyhow::Result<Vec<String>> {
+    async fn process(&self, evs: &[&ScanEvent]) -> anyhow::Result<Vec<String>> {
         let mut succeeded = Vec::new();
 
         for ev in evs {

--- a/src/service/targets/plex.rs
+++ b/src/service/targets/plex.rs
@@ -228,7 +228,7 @@ impl Plex {
 }
 
 impl TargetProcess for Plex {
-    async fn process<'a>(&self, evs: &[&'a ScanEvent]) -> anyhow::Result<Vec<String>> {
+    async fn process(&self, evs: &[&ScanEvent]) -> anyhow::Result<Vec<String>> {
         let libraries = self.libraries().await?;
 
         let mut succeeded = Vec::new();

--- a/src/service/targets/tdarr.rs
+++ b/src/service/targets/tdarr.rs
@@ -80,7 +80,7 @@ impl Tdarr {
 }
 
 impl TargetProcess for Tdarr {
-    async fn process<'a>(&self, evs: &[&'a ScanEvent]) -> anyhow::Result<Vec<String>> {
+    async fn process(&self, evs: &[&ScanEvent]) -> anyhow::Result<Vec<String>> {
         let mut succeeded = Vec::new();
 
         self.scan(evs).await?;

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -4,7 +4,7 @@ use auth::Auth;
 use config::Config;
 use opts::Opts;
 use serde::Deserialize;
-use std::collections::HashMap;
+use std::{collections::HashMap, path::PathBuf};
 use target::Target;
 use timer::Timer;
 use trigger::Trigger;
@@ -123,6 +123,20 @@ pub struct Settings {
 
     #[serde(default)]
     pub webhooks: HashMap<String, Webhook>,
+
+    /// List of paths to anchor the service to
+    ///
+    /// This is useful to prevent the service notifying a target when the drive is not mounted or visible
+    /// The contents of the file/directory are not tampered with, only the presence of the file/directory is checked
+    ///
+    /// Example:
+    /// ```yml
+    /// anchors:
+    ///  - /mnt/media/tv # Directory
+    ///  - /mnt/media/anchor # File
+    /// ```
+    #[serde(default)]
+    pub anchors: Vec<PathBuf>,
 }
 
 impl Settings {

--- a/src/settings/target.rs
+++ b/src/settings/target.rs
@@ -9,9 +9,9 @@ use crate::{
 };
 
 pub trait TargetProcess {
-    fn process<'a>(
+    fn process(
         &self,
-        evs: &[&'a ScanEvent],
+        evs: &[&ScanEvent],
     ) -> impl std::future::Future<Output = anyhow::Result<Vec<String>>> + Send;
 }
 


### PR DESCRIPTION
# Description

Adds anchors, preventing the service from processing events when the anchors are not available

Example:

```yml
anchors:
  - /mnt/media # Directories
  - /mnt/media/tv # More fine-grained directories
  - /mnt/media/test.txt # Files
```

Closes #126 

## Type of change

<!-- Fill in the appropriate box like so: [x] -->

- [ ] Bug (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (addition or change to documentation)

<!-- 
Before you submit, consider this checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
-->
