### PR TITLE
fix(emby): paginate item search

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG IMAGE_TAG=3.20
-FROM --platform=$BUILDPLATFORM ghcr.io/linuxserver/baseimage-alpine:${IMAGE_TAG} AS runtime
+FROM --platform=$TARGETPLATFORM ghcr.io/linuxserver/baseimage-alpine:${IMAGE_TAG} AS runtime
 
 WORKDIR /app
 

--- a/Dockerfile.src
+++ b/Dockerfile.src
@@ -1,6 +1,6 @@
 # Install cargo-chef for a base step
 ARG BUILD_IMAGE=clux/muslrust:stable
-FROM --platform=$BUILDPLATFORM ${BUILD_IMAGE} AS chef
+FROM --platform=$TARGETPLATFORM ${BUILD_IMAGE} AS chef
 USER root
 RUN cargo install cargo-chef
 WORKDIR /app
@@ -32,7 +32,7 @@ RUN cargo build --release --target ${TARGET} --no-default-features --features ${
 
 RUN cp target/${TARGET}/release/autopulse /tmp/autopulse
 
-FROM --platform=$BUILDPLATFORM alpine AS runtime
+FROM --platform=$TARGETPLATFORM alpine AS runtime
 
 WORKDIR /app
 


### PR DESCRIPTION
# Description

Paginate the `GET /Items` response to reduce timeouts

Possibly solves #133 

## Type of change

- [x] Bug (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (addition or change to documentation)

<!-- 
Before you submit, consider this checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
-->
