### PR TITLE
bug(emby/jellyfin): typo in client header for emby

### DIFF
--- a/src/service/targets/emby.rs
+++ b/src/service/targets/emby.rs
@@ -103,7 +103,7 @@ impl Emby {
         let mut headers = header::HeaderMap::new();
 
         headers.insert(
-            "Authorzation",
+            "Authorization",
             format!("MediaBrowser Token=\"{}\"", self.token)
                 .parse()
                 .unwrap(),


### PR DESCRIPTION
Wrong header name (typo)

# Description

Header name for emby/jellyfin needed for authorization has a typo.

<!-- Closes #(issue) -->

## Type of change

<!-- Fill in the appropriate box like so: [x] -->

- [x] Bug (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (addition or change to documentation)

