### PR TITLE
refactor(targets): use `get_url` util for subpaths

### DIFF
--- a/src/service/targets/autopulse.rs
+++ b/src/service/targets/autopulse.rs
@@ -1,6 +1,7 @@
 use crate::{
     db::models::ScanEvent,
     settings::{auth::Auth, target::TargetProcess},
+    utils::get_url::get_url,
 };
 use reqwest::header;
 use serde::Deserialize;
@@ -35,7 +36,7 @@ impl Autopulse {
 
     async fn scan(&self, ev: &ScanEvent) -> anyhow::Result<()> {
         let client = self.get_client()?;
-        let mut url = url::Url::parse(&self.url)?.join("/triggers/manual")?;
+        let mut url = get_url(&self.url)?.join("triggers/manual")?;
 
         url.query_pairs_mut().append_pair("path", &ev.file_path);
 

--- a/src/service/targets/fileflows.rs
+++ b/src/service/targets/fileflows.rs
@@ -1,4 +1,4 @@
-use crate::{db::models::ScanEvent, settings::target::TargetProcess};
+use crate::{db::models::ScanEvent, settings::target::TargetProcess, utils::get_url::get_url};
 use anyhow::Context;
 use reqwest::header;
 use serde::{Deserialize, Serialize};
@@ -97,7 +97,7 @@ impl FileFlows {
     async fn get_libraries(&self) -> anyhow::Result<Vec<FileFlowsLibrary>> {
         let client = self.get_client()?;
 
-        let url = url::Url::parse(&self.url)?.join("/api/library")?;
+        let url = get_url(&self.url)?.join("api/library")?;
 
         let res = client.get(url.to_string()).send().await?;
         let status = res.status();
@@ -123,7 +123,7 @@ impl FileFlows {
     ) -> anyhow::Result<Option<FileFlowsLibraryFile>> {
         let client = self.get_client()?;
 
-        let url = url::Url::parse(&self.url)?.join("/api/library-file/search")?;
+        let url = get_url(&self.url)?.join("api/library-file/search")?;
 
         let req = FileFlowsSearchRequest {
             path: ev.file_path.clone(),
@@ -151,7 +151,7 @@ impl FileFlows {
     async fn reprocess_library_filse(&self, evs: Vec<&FileFlowsLibraryFile>) -> anyhow::Result<()> {
         let client = self.get_client()?;
 
-        let url = url::Url::parse(&self.url)?.join("/api/library-file/reprocess")?;
+        let url = get_url(&self.url)?.join("api/library-file/reprocess")?;
 
         let req = FileFlowsReprocessRequest {
             uids: evs.iter().map(|ev| ev.uid.clone()).collect(),
@@ -181,7 +181,7 @@ impl FileFlows {
     ) -> anyhow::Result<()> {
         let client = self.get_client()?;
 
-        let url = url::Url::parse(&self.url)?.join("/api/library-file/manually-add")?;
+        let url = get_url(&self.url)?.join("api/library-file/manually-add")?;
 
         let req = FileFlowsManuallyAddRequest {
             flow_uid: library.flow.as_ref().unwrap().uid.clone(),
@@ -208,7 +208,7 @@ impl FileFlows {
     // async fn rescan_library(&self, libraries: &FileFlowsLibrary) -> anyhow::Result<()> {
     //     let client = self.get_client()?;
 
-    //     let url = url::Url::parse(&self.url)?.join("/api/library/rescan")?;
+    //     let url = get_url(&self.url)?.join("/api/library/rescan")?;
 
     //     let req = FileFlowsRescanLibraryRequest {
     //         uids: vec![libraries.uid.clone()],
@@ -228,7 +228,7 @@ impl FileFlows {
     // async fn scan(&self, ev: &ScanEvent, library: &FileFlowsLibrary) -> anyhow::Result<()> {
     //     let client = self.get_client()?;
 
-    //     let mut url = url::Url::parse(&self.url)?.join("/api/library-file/process-file")?;
+    //     let mut url = get_url(&self.url)?.join("/api/library-file/process-file")?;
 
     //     url.query_pairs_mut().append_pair("filename", &ev.file_path);
 

--- a/src/service/targets/plex.rs
+++ b/src/service/targets/plex.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use crate::{db::models::ScanEvent, settings::target::TargetProcess};
+use crate::{db::models::ScanEvent, settings::target::TargetProcess, utils::get_url::get_url};
 use anyhow::Context;
 use reqwest::header;
 use serde::Deserialize;
@@ -96,9 +96,7 @@ impl Plex {
 
     async fn libraries(&self) -> anyhow::Result<Vec<Library>> {
         let client = self.get_client()?;
-        let url = url::Url::parse(&self.url)?
-            .join("/library/sections")?
-            .to_string();
+        let url = get_url(&self.url)?.join("library/sections")?.to_string();
 
         let res = client.get(&url).send().await?;
         let status = res.status();
@@ -138,8 +136,8 @@ impl Plex {
     // TODO: Change to get_items
     async fn get_item(&self, library: &Library, path: &str) -> anyhow::Result<Option<Metadata>> {
         let client = self.get_client()?;
-        let url = url::Url::parse(&self.url)?
-            .join(&format!("/library/sections/{}/all", library.key))?
+        let url = get_url(&self.url)?
+            .join(&format!("library/sections/{}/all", library.key))?
             .to_string();
 
         let res = client.get(&url).send().await?;
@@ -175,7 +173,7 @@ impl Plex {
     // async fn refresh_library(&self, library: &str) -> anyhow::Result<()> {
     //     let client = self.get_client()?;
     //     let mut url =
-    //         url::Url::parse(&self.url)?.join(&format!("/library/sections/{}/refresh", library))?;
+    //         get_url(&self.url)?.join(&format!("/library/sections/{}/refresh", library))?;
 
     //     url.query_pairs_mut().append_pair("force", "1");
 
@@ -192,7 +190,7 @@ impl Plex {
     // async fn analyze_library(&self, library: &str) -> anyhow::Result<()> {
     //     let client = self.get_client()?;
     //     let url =
-    //         url::Url::parse(&self.url)?.join(&format!("/library/sections/{}/analyze", library))?;
+    //         get_url(&self.url)?.join(&format!("/library/sections/{}/analyze", library))?;
 
     //     let res = client.put(url.to_string()).send().await?;
 
@@ -206,7 +204,7 @@ impl Plex {
 
     async fn refresh_item(&self, key: &str) -> anyhow::Result<()> {
         let client = self.get_client()?;
-        let url = url::Url::parse(&self.url)?.join(&format!("{}/refresh", key))?;
+        let url = get_url(&self.url)?.join(&format!("{}/refresh", key))?;
 
         let res = client.put(url.to_string()).send().await?;
 
@@ -220,7 +218,7 @@ impl Plex {
 
     async fn analyze_item(&self, key: &str) -> anyhow::Result<()> {
         let client = self.get_client()?;
-        let url = url::Url::parse(&self.url)?.join(&format!("{}/analyze", key))?;
+        let url = get_url(&self.url)?.join(&format!("{}/analyze", key))?;
 
         let res = client.put(url.to_string()).send().await?;
 
@@ -234,8 +232,8 @@ impl Plex {
 
     async fn scan(&self, ev: &ScanEvent, library: &Library) -> anyhow::Result<()> {
         let client = self.get_client()?;
-        let mut url = url::Url::parse(&self.url)?
-            .join(&format!("/library/sections/{}/refresh", library.key))?;
+        let mut url =
+            get_url(&self.url)?.join(&format!("library/sections/{}/refresh", library.key))?;
 
         let file_dir = std::path::Path::new(&ev.file_path)
             .parent()

--- a/src/service/targets/tdarr.rs
+++ b/src/service/targets/tdarr.rs
@@ -1,7 +1,7 @@
 use reqwest::header;
 use serde::{Deserialize, Serialize};
 
-use crate::{db::models::ScanEvent, settings::target::TargetProcess};
+use crate::{db::models::ScanEvent, settings::target::TargetProcess, utils::get_url::get_url};
 
 #[derive(Deserialize, Clone)]
 pub struct Tdarr {
@@ -59,9 +59,7 @@ impl Tdarr {
             },
         };
 
-        let url = url::Url::parse(&self.url)?
-            .join("/api/v2/scan-files")?
-            .to_string();
+        let url = get_url(&self.url)?.join("/api/v2/scan-files")?.to_string();
 
         let res = client
             .post(&url)

--- a/src/tests/utils/get_url.rs
+++ b/src/tests/utils/get_url.rs
@@ -1,0 +1,31 @@
+#[cfg(test)]
+mod tests {
+    use crate::utils::get_url::get_url;
+
+    #[test]
+    fn test_join_no_subpath() -> anyhow::Result<()> {
+        let url = "http://example.com".to_string();
+
+        let parsed = get_url(&url)?;
+
+        assert_eq!(parsed.to_string(), "http://example.com/");
+        assert_eq!(parsed.join("test")?.to_string(), "http://example.com/test");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_join_with_subpath() -> anyhow::Result<()> {
+        let url = "http://example.com/test".to_string();
+
+        let parsed = get_url(&url)?;
+
+        assert_eq!(parsed.to_string(), "http://example.com/test/");
+        assert_eq!(
+            parsed.join("test")?.to_string(),
+            "http://example.com/test/test"
+        );
+
+        Ok(())
+    }
+}

--- a/src/tests/utils/mod.rs
+++ b/src/tests/utils/mod.rs
@@ -1,6 +1,7 @@
 pub mod check_auth;
 pub mod checksum;
 pub mod generate_uuid;
+pub mod get_url;
 pub mod join_path;
 pub mod rewrite;
 pub mod sify;

--- a/src/utils/get_url.rs
+++ b/src/utils/get_url.rs
@@ -1,0 +1,10 @@
+use std::borrow::Cow;
+
+pub fn get_url(url: &str) -> anyhow::Result<url::Url> {
+    let url: Cow<str> = if url.ends_with('/') {
+        Cow::Borrowed(url)
+    } else {
+        format!("{}/", url).into()
+    };
+    url::Url::parse(&url).map_err(Into::into)
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -7,6 +7,8 @@ pub mod generate_uuid;
 #[doc(hidden)]
 pub mod get_timestamp;
 #[doc(hidden)]
+pub mod get_url;
+#[doc(hidden)]
 pub mod join_path;
 #[doc(hidden)]
 pub mod logs;


### PR DESCRIPTION
# Description

Fixes path joining in:

- [x] Emby/Jellyfin
- [x] Autopulse
- [x] Fileflows
- [x] Plex
- [x] Tdarr

Closes #149 

## Type of change

<!-- Fill in the appropriate box like so: [x] -->

- [x] Bug (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (addition or change to documentation)


## Technical

Parsed urls technically kept their path but unless the original url ended in a "/", future `join` calls would override instead of- join

```rust
fn get_url(&self) -> anyhow::Result<url::Url> {
    let url = if self.url.ends_with('/') {
        self.url.clone()
    } else {
        format!("{}/", self.url)
    };

    url::Url::parse(&url).map_err(Into::into)
}
```

<!-- 
Before you submit, consider this checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
-->
