### PR TITLE
feat(webhooks): add hookshot and generic json webhook support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,17 +253,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
-name = "async-recursion"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,13 +328,13 @@ name = "autopulse-service"
 version = "1.5.0"
 dependencies = [
  "anyhow",
- "async-recursion",
  "autopulse-database",
  "autopulse-utils",
  "base64",
  "chrono",
  "config",
  "futures",
+ "html-escape",
  "notify-debouncer-full",
  "reqwest",
  "serde",
@@ -942,7 +931,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1247,6 +1236,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "html-escape"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476"
+dependencies = [
+ "utf8-width",
+]
 
 [[package]]
 name = "http"
@@ -1855,7 +1853,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2399,7 +2397,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2456,7 +2454,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2823,10 +2821,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3248,6 +3246,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3466,7 +3470,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ We use the following terminology:
 - **Integration**: integrates with Sonarr, Radarr, Plex, Jellyfin, and more in the future
 - **Checks**: checks the file exists before updating the target and optionally waits for the file to match a provided hash
 - **Reliability**: uses a database to store the state of the scan requests
-- **Webhooks**: allow for notifications to be sent when a file is ready to be processed with webhooks such as Discord
+- **Webhooks**: allow for notifications to be sent when a file is ready to be processed with Discord, Matrix Hookshot, or generic JSON webhooks
 - **User-Interface**: provides a simple web interface to view/add scan requests
 
 ## Getting Started
@@ -183,6 +183,14 @@ webhooks:
   my_discord:
     type: "discord"
     url: "https://discord.com/api/webhooks/1234567890/abcdefg"
+
+  my_hookshot:
+    type: "hookshot"
+    url: "https://matrix.example.com/_matrix/hookshot/webhook/abcdefg"
+
+  my_json:
+    type: "json"
+    url: "https://example.com/webhooks/autopulse"
 
 targets:
   my_plex:

--- a/crates/service/Cargo.toml
+++ b/crates/service/Cargo.toml
@@ -33,9 +33,11 @@ config = "0.15.6"
 # File system notifications
 notify-debouncer-full = "0.7.0"
 
+# HTML encoding
+html-escape = "0.2"
+
 # Other
 struson = { version = "0.7.0", features = [
     "simple-api",
     "serde",
 ] } # Parse Jellyfin response as a stream
-async-recursion = "1.1.1" # Retry requests for webhooks

--- a/crates/service/src/manager.rs
+++ b/crates/service/src/manager.rs
@@ -220,10 +220,13 @@ impl PulseManager {
     }
 
     pub async fn start_webhooks(&self) -> anyhow::Result<()> {
-        let mut timer = tokio::time::interval(std::time::Duration::from_secs(10));
+        let interval = std::time::Duration::from_secs(self.settings.opts.webhook_interval);
+        let mut timer = tokio::time::interval(interval);
 
         loop {
-            self.webhooks.send().await?;
+            if let Err(e) = self.webhooks.send().await {
+                error!("webhook batch send failed: {e}");
+            }
 
             timer.tick().await;
         }

--- a/crates/service/src/settings/opts.rs
+++ b/crates/service/src/settings/opts.rs
@@ -22,6 +22,21 @@ const fn default_cleanup_days() -> u64 {
     10
 }
 
+#[doc(hidden)]
+const fn default_webhook_retries() -> u8 {
+    3
+}
+
+#[doc(hidden)]
+const fn default_webhook_timeout() -> u64 {
+    10
+}
+
+#[doc(hidden)]
+const fn default_webhook_interval() -> u64 {
+    10
+}
+
 #[derive(Serialize, Clone, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum LogRotation {
@@ -79,6 +94,18 @@ pub struct Opts {
     /// Whether to rollover the log file (default: never)
     #[serde(default)]
     pub log_file_rollover: LogRotation,
+
+    /// Number of retries for webhook HTTP requests (default: 3)
+    #[serde(default = "default_webhook_retries")]
+    pub webhook_retries: u8,
+
+    /// HTTP timeout in seconds for webhook requests (default: 10)
+    #[serde(default = "default_webhook_timeout")]
+    pub webhook_timeout: u64,
+
+    /// Interval in seconds between webhook batch sends (default: 10)
+    #[serde(default = "default_webhook_interval")]
+    pub webhook_interval: u64,
 }
 
 impl Default for Opts {
@@ -90,6 +117,9 @@ impl Default for Opts {
             cleanup_days: default_cleanup_days(),
             log_file: None,
             log_file_rollover: LogRotation::default(),
+            webhook_retries: default_webhook_retries(),
+            webhook_timeout: default_webhook_timeout(),
+            webhook_interval: default_webhook_interval(),
         }
     }
 }

--- a/crates/service/src/settings/webhooks/discord.rs
+++ b/crates/service/src/settings/webhooks/discord.rs
@@ -1,7 +1,6 @@
-use super::{EventType, WebhookBatch};
-use autopulse_utils::{get_timestamp, sify};
+use super::{transport, EventType, WebhookBatch};
+use autopulse_utils::sify;
 use serde::{Deserialize, Serialize};
-use tracing::trace;
 
 #[derive(Serialize, Clone)]
 #[doc(hidden)]
@@ -38,22 +37,19 @@ pub struct DiscordWebhook {
 }
 
 impl DiscordWebhook {
-    fn get_client(&self) -> reqwest::Client {
-        reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(10))
-            .build()
-            .expect("failed to build reqwest client")
-    }
-
     fn truncate_message(message: String, length: usize) -> String {
-        if message.len() > length {
-            format!("{}...", &message[..(length - 3)])
-        } else {
-            message
+        if length < 3 || message.len() <= length {
+            return message;
         }
+
+        let cut = message.floor_char_boundary(length - 3);
+        format!("{}...", &message[..cut])
     }
 
-    fn generate_json(&self, batch: &WebhookBatch) -> DiscordEmbedContent {
+    fn generate_json(
+        &self,
+        batch: &[(EventType, Option<String>, Vec<String>)],
+    ) -> DiscordEmbedContent {
         let mut content = DiscordEmbedContent {
             username: self
                 .username
@@ -67,6 +63,8 @@ impl DiscordWebhook {
         };
 
         for (event, trigger, files) in batch {
+            let timestamp = chrono::Utc::now().to_rfc3339();
+
             let color = match event {
                 EventType::New => 6_061_450,     // grey
                 EventType::Found => 52084,       // green
@@ -100,7 +98,7 @@ impl DiscordWebhook {
             let fields = vec![
                 DiscordEmbedField {
                     name: "Timestamp".to_string(),
-                    value: get_timestamp(),
+                    value: timestamp.clone(),
                 },
                 DiscordEmbedField {
                     name: "Files".to_string(),
@@ -111,7 +109,7 @@ impl DiscordWebhook {
 
             let embed = DiscordEmbed {
                 color,
-                timestamp: chrono::Utc::now().to_rfc3339(),
+                timestamp,
                 fields,
                 title,
             };
@@ -122,58 +120,64 @@ impl DiscordWebhook {
         content
     }
 
-    #[async_recursion::async_recursion]
-    pub async fn send(&self, batch: &WebhookBatch, retries: u8) -> anyhow::Result<()> {
+    pub async fn send(
+        &self,
+        batch: &WebhookBatch,
+        retries: u8,
+        timeout_secs: u64,
+    ) -> anyhow::Result<()> {
         let mut message_queue = vec![];
 
         for chunk in batch.chunks(10) {
-            let content = self.generate_json(&chunk.to_vec());
+            let content = self.generate_json(chunk);
             message_queue.push(content);
         }
 
-        for message in message_queue {
-            let res = self
-                .get_client()
-                .post(&self.url)
-                .json(&message)
-                .send()
-                .await
-                .map_err(|e| anyhow::anyhow!(e))?;
+        transport::shared_sender(std::time::Duration::from_secs(timeout_secs))?
+            .send_json(&self.url, &message_queue, retries)
+            .await
+    }
+}
 
-            if !res.status().is_success() {
-                let reset = res.headers().get("X-RateLimit-Reset");
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-                if let Some(reset) = reset {
-                    if retries == 0 {
-                        let body = res.text().await?;
+    #[test]
+    fn truncate_ascii_under_limit() {
+        let input = "short".to_string();
+        assert_eq!(DiscordWebhook::truncate_message(input, 10), "short");
+    }
 
-                        return Err(anyhow::anyhow!(
-                            "failed to send webhook, retries exhausted: {body}"
-                        ));
-                    }
+    #[test]
+    fn truncate_ascii_over_limit() {
+        let input = "this is a long message".to_string();
+        let result = DiscordWebhook::truncate_message(input, 10);
+        assert_eq!(result, "this is...");
+        assert_eq!(result.len(), 10);
+    }
 
-                    let reset = reset.to_str().unwrap_or_default();
-                    let reset = reset.parse::<u64>().unwrap_or_default();
-                    let now = chrono::Utc::now().timestamp() as u64;
+    #[test]
+    fn truncate_multibyte_at_boundary() {
+        // '😀' is 4 bytes; cutting mid-emoji must not panic
+        let input = "abcde😀fgh".to_string();
+        // length=8 → cut at 5, but byte 5 is inside the 4-byte emoji (bytes 5..9)
+        // floor_char_boundary(5) should back up to byte 5 which is the start of 😀
+        let result = DiscordWebhook::truncate_message(input, 8);
+        assert!(result.ends_with("..."));
+        assert!(result.is_char_boundary(result.len()));
+    }
 
-                    if reset > now {
-                        let wait = reset.saturating_sub(now);
+    #[test]
+    fn truncate_empty_string() {
+        let result = DiscordWebhook::truncate_message(String::new(), 10);
+        assert_eq!(result, "");
+    }
 
-                        trace!("rate limited, waiting for {} seconds", wait);
-
-                        tokio::time::sleep(tokio::time::Duration::from_secs(wait)).await;
-
-                        self.send(batch, retries - 1).await?;
-                        continue;
-                    }
-                }
-
-                let body = res.text().await.unwrap_or_else(|_| "no body".to_string());
-
-                return Err(anyhow::anyhow!("failed to send webhook: {}", body));
-            }
-        }
-
-        Ok(())
+    #[test]
+    fn truncate_exactly_at_limit() {
+        let input = "exactly 10".to_string();
+        assert_eq!(input.len(), 10);
+        assert_eq!(DiscordWebhook::truncate_message(input, 10), "exactly 10");
     }
 }

--- a/crates/service/src/settings/webhooks/hookshot.rs
+++ b/crates/service/src/settings/webhooks/hookshot.rs
@@ -1,0 +1,164 @@
+use super::{transport, EventType, WebhookBatch};
+use autopulse_utils::sify;
+use html_escape::encode_text;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Clone)]
+struct HookshotPayload {
+    text: String,
+    html: String,
+    username: String,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct HookshotWebhook {
+    /// Webhook URL
+    pub url: String,
+    /// Optional username (default: autopulse)
+    pub username: Option<String>,
+}
+
+impl HookshotWebhook {
+    fn summary_line(event: &EventType, trigger: Option<&str>, files: &[String]) -> String {
+        trigger.map_or_else(
+            || {
+                format!(
+                    "[{event}] - {} file{} {}",
+                    files.len(),
+                    sify(files),
+                    event.action()
+                )
+            },
+            |trigger| {
+                format!(
+                    "[{event}] - [{trigger}] - {} file{} {}",
+                    files.len(),
+                    sify(files),
+                    event.action()
+                )
+            },
+        )
+    }
+
+    fn generate_payload(&self, batch: &WebhookBatch) -> HookshotPayload {
+        let username = self
+            .username
+            .clone()
+            .unwrap_or_else(|| "autopulse".to_string());
+        let sections = batch
+            .iter()
+            .map(|(event, trigger, files)| {
+                let summary = Self::summary_line(event, trigger.as_deref(), files);
+                let files = files.join("\n");
+
+                format!("{summary}\n{files}")
+            })
+            .collect::<Vec<_>>();
+        let text = sections.join("\n\n");
+        let html = batch
+            .iter()
+            .map(|(event, trigger, files)| {
+                let raw_summary = Self::summary_line(event, trigger.as_deref(), files);
+                let summary = encode_text(&raw_summary);
+                let files = files
+                    .iter()
+                    .map(|file| format!("<li><code>{}</code></li>", encode_text(file)))
+                    .collect::<Vec<_>>()
+                    .join("");
+
+                format!("<li><strong>{summary}</strong><ul>{files}</ul></li>")
+            })
+            .collect::<Vec<_>>()
+            .join("");
+        let html = format!("<ul>{html}</ul>");
+
+        HookshotPayload {
+            text,
+            html,
+            username,
+        }
+    }
+
+    pub async fn send(
+        &self,
+        batch: &WebhookBatch,
+        retries: u8,
+        timeout_secs: u64,
+    ) -> anyhow::Result<()> {
+        let payload = self.generate_payload(batch);
+
+        transport::shared_sender(std::time::Duration::from_secs(timeout_secs))?
+            .send_json(&self.url, &[payload], retries)
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_batch() -> WebhookBatch {
+        vec![
+            (
+                EventType::Processed,
+                Some("sonarr".to_string()),
+                vec!["/media/tv/show-01.mkv".to_string()],
+            ),
+            (
+                EventType::Failed,
+                None,
+                vec!["/media/movies/movie-01.mkv".to_string()],
+            ),
+        ]
+    }
+
+    #[test]
+    fn generate_payload_defaults_username_and_summarizes_each_batch_item() {
+        let webhook = HookshotWebhook {
+            url: "https://example.com/webhooks/hookshot".to_string(),
+            username: None,
+        };
+
+        let payload = webhook.generate_payload(&sample_batch());
+
+        assert_eq!(payload.username, "autopulse");
+        assert!(payload
+            .text
+            .contains("[PROCESSED] - [sonarr] - 1 file processed"));
+        assert!(payload.text.contains("/media/tv/show-01.mkv"));
+        assert!(payload.text.contains("[FAILED] - 1 file failed"));
+        assert!(payload
+            .html
+            .contains("<code>/media/movies/movie-01.mkv</code>"));
+    }
+
+    #[test]
+    fn html_entities_in_filenames_are_escaped() {
+        let batch: WebhookBatch = vec![(
+            EventType::Processed,
+            Some("sonarr".to_string()),
+            vec![
+                r#"/media/tv/<script>alert("xss")</script>.mkv"#.to_string(),
+                "/media/tv/Tom & Jerry's Show.mkv".to_string(),
+            ],
+        )];
+
+        let webhook = HookshotWebhook {
+            url: "https://example.com/hook".to_string(),
+            username: None,
+        };
+
+        let payload = webhook.generate_payload(&batch);
+
+        // Angle brackets escaped
+        assert!(payload.html.contains("&lt;script&gt;"));
+        assert!(payload.html.contains("&lt;/script&gt;"));
+        // Ampersand escaped
+        assert!(payload.html.contains("Tom &amp; Jerry"));
+        // Quotes are safe in text nodes and left unescaped by encode_text
+        assert!(payload.html.contains(r#"alert("xss")"#));
+        assert!(payload.html.contains("Jerry's"));
+        // Raw angle brackets must NOT appear in HTML output
+        assert!(!payload.html.contains("<script>"));
+    }
+}

--- a/crates/service/src/settings/webhooks/json.rs
+++ b/crates/service/src/settings/webhooks/json.rs
@@ -1,0 +1,102 @@
+use super::{transport, WebhookBatch};
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Clone)]
+struct JsonWebhookEvent {
+    event: String,
+    action: String,
+    trigger: Option<String>,
+    files: Vec<String>,
+    file_count: usize,
+    timestamp: String,
+}
+
+#[derive(Serialize, Clone)]
+struct JsonWebhookPayload {
+    events: Vec<JsonWebhookEvent>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct JsonWebhook {
+    /// Webhook URL
+    pub url: String,
+}
+
+impl JsonWebhook {
+    fn generate_payload(&self, batch: &WebhookBatch) -> JsonWebhookPayload {
+        let timestamp = Utc::now().to_rfc3339();
+        let events = batch
+            .iter()
+            .map(|(event, trigger, files)| JsonWebhookEvent {
+                event: event.key().to_string(),
+                action: event.action().to_string(),
+                trigger: trigger.clone(),
+                files: files.clone(),
+                file_count: files.len(),
+                timestamp: timestamp.clone(),
+            })
+            .collect();
+
+        JsonWebhookPayload { events }
+    }
+
+    pub async fn send(
+        &self,
+        batch: &WebhookBatch,
+        retries: u8,
+        timeout_secs: u64,
+    ) -> anyhow::Result<()> {
+        let payload = self.generate_payload(batch);
+
+        transport::shared_sender(std::time::Duration::from_secs(timeout_secs))?
+            .send_json(&self.url, &[payload], retries)
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::settings::webhooks::EventType;
+
+    #[test]
+    fn generate_payload_exposes_stable_event_fields() {
+        let webhook = JsonWebhook {
+            url: "https://example.com/webhooks/json".to_string(),
+        };
+        let batch = vec![
+            (
+                EventType::New,
+                Some("sonarr".to_string()),
+                vec!["/media/tv/show-01.mkv".to_string()],
+            ),
+            (
+                EventType::HashMismatch,
+                None,
+                vec!["/media/tv/show-02.mkv".to_string()],
+            ),
+        ];
+
+        let payload = serde_json::to_value(webhook.generate_payload(&batch)).unwrap();
+        let events = payload
+            .get("events")
+            .and_then(serde_json::Value::as_array)
+            .unwrap();
+
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0]["event"], "new");
+        assert_eq!(events[0]["action"], "added");
+        assert_eq!(events[0]["trigger"], "sonarr");
+        assert_eq!(
+            events[0]["files"],
+            serde_json::json!(["/media/tv/show-01.mkv"])
+        );
+        assert_eq!(events[0]["file_count"], 1);
+        assert!(
+            chrono::DateTime::parse_from_rfc3339(events[0]["timestamp"].as_str().unwrap()).is_ok()
+        );
+        assert_eq!(events[1]["event"], "hash_mismatch");
+        assert!(events[1]["trigger"].is_null());
+    }
+}

--- a/crates/service/src/settings/webhooks/manager.rs
+++ b/crates/service/src/settings/webhooks/manager.rs
@@ -1,4 +1,5 @@
 use crate::settings::Settings;
+use futures::future::join_all;
 use std::{collections::HashMap, fmt::Display, sync::Arc};
 use tokio::sync::RwLock;
 use tracing::error;
@@ -39,7 +40,18 @@ impl Display for EventType {
 }
 
 impl EventType {
-    pub fn action(&self) -> String {
+    pub fn key(&self) -> &'static str {
+        match self {
+            Self::New => "new",
+            Self::Found => "found",
+            Self::Retrying => "retrying",
+            Self::Failed => "failed",
+            Self::Processed => "processed",
+            Self::HashMismatch => "hash_mismatch",
+        }
+    }
+
+    pub fn action(&self) -> &'static str {
         match self {
             Self::New => "added",
             Self::Found => "found",
@@ -48,7 +60,6 @@ impl EventType {
             Self::Processed => "processed",
             Self::HashMismatch => "mismatched",
         }
-        .to_string()
     }
 }
 
@@ -76,6 +87,8 @@ impl WebhookManager {
     pub async fn send(&self) -> anyhow::Result<()> {
         let mut queue = self.queue.write().await;
         let webhooks = &self.settings.webhooks;
+        let retries = self.settings.opts.webhook_retries;
+        let timeout_secs = self.settings.opts.webhook_timeout;
 
         let mut batch = queue
             .drain()
@@ -86,13 +99,19 @@ impl WebhookManager {
 
         batch.sort_by(|(a, _, _), (b, _, _)| a.cmp(b));
 
-        for (name, webhook) in webhooks {
-            let webhook = webhook.clone();
+        let futures: Vec<_> = webhooks
+            .iter()
+            .map(|(name, webhook)| {
+                let batch = &batch;
+                async move {
+                    if let Err(e) = webhook.send(batch, retries, timeout_secs).await {
+                        error!("failed to send webhook '{}': {}", name, e);
+                    }
+                }
+            })
+            .collect();
 
-            if let Err(e) = webhook.send(&batch).await {
-                error!("failed to send webhook '{}': {}", name, e);
-            }
-        }
+        join_all(futures).await;
 
         Ok(())
     }

--- a/crates/service/src/settings/webhooks/mod.rs
+++ b/crates/service/src/settings/webhooks/mod.rs
@@ -24,25 +24,116 @@
 /// See [`DiscordWebhook`] for all options
 pub mod discord;
 
+/// Hookshot - Matrix Hookshot inbound webhook
+///
+/// Sends a Matrix Hookshot-compatible JSON body with `text`, generated `html`,
+/// and an optional `username`
+///
+/// # Example
+///
+/// ```yml
+/// webhooks:
+///   my_hookshot:
+///     type: hookshot
+///     url: "https://matrix.example.com/_matrix/hookshot/webhook/..."
+/// ```
+///
+/// See [`HookshotWebhook`] for all options
+pub mod hookshot;
+
+/// JSON - generic structured webhook payload
+///
+/// Sends a stable JSON object with an `events` array for generic webhook
+/// consumers
+///
+/// # Example
+///
+/// ```yml
+/// webhooks:
+///   my_json:
+///     type: json
+///     url: "https://example.com/webhooks/autopulse"
+/// ```
+///
+/// See [`JsonWebhook`] for all options
+pub mod json;
+
 #[doc(hidden)]
 pub mod manager;
+
+#[doc(hidden)]
+pub mod transport;
 
 #[doc(hidden)]
 pub use manager::*;
 
 use discord::DiscordWebhook;
+use hookshot::HookshotWebhook;
+use json::JsonWebhook;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum Webhook {
     Discord(DiscordWebhook),
+    Hookshot(HookshotWebhook),
+    Json(JsonWebhook),
 }
 
 impl Webhook {
-    pub async fn send(&self, batch: &WebhookBatch) -> anyhow::Result<()> {
-        match self {
-            Self::Discord(d) => d.send(batch, 3).await,
+    pub async fn send(
+        &self,
+        batch: &WebhookBatch,
+        retries: u8,
+        timeout_secs: u64,
+    ) -> anyhow::Result<()> {
+        if batch.is_empty() {
+            return Ok(());
         }
+
+        match self {
+            Self::Discord(d) => d.send(batch, retries, timeout_secs).await,
+            Self::Hookshot(h) => h.send(batch, retries, timeout_secs).await,
+            Self::Json(j) => j.send(batch, retries, timeout_secs).await,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{hookshot::HookshotWebhook, json::JsonWebhook, Webhook};
+
+    #[test]
+    fn deserializes_hookshot_webhook_config() {
+        let webhook = serde_json::from_value::<Webhook>(serde_json::json!({
+            "type": "hookshot",
+            "url": "https://example.com/webhooks/hookshot"
+        }));
+
+        assert!(webhook.is_ok(), "expected hookshot webhook to deserialize");
+    }
+
+    #[test]
+    fn deserializes_json_webhook_config() {
+        let webhook = serde_json::from_value::<Webhook>(serde_json::json!({
+            "type": "json",
+            "url": "https://example.com/webhooks/json"
+        }));
+
+        assert!(webhook.is_ok(), "expected json webhook to deserialize");
+    }
+
+    #[tokio::test]
+    async fn skips_sending_empty_batches() {
+        let hookshot = Webhook::Hookshot(HookshotWebhook {
+            url: "http://127.0.0.1:9/hookshot".to_string(),
+            username: None,
+        });
+        let json = Webhook::Json(JsonWebhook {
+            url: "http://127.0.0.1:9/json".to_string(),
+        });
+
+        hookshot.send(&Vec::new(), 3, 10).await.unwrap();
+        json.send(&Vec::new(), 3, 10).await.unwrap();
     }
 }

--- a/crates/service/src/settings/webhooks/transport.rs
+++ b/crates/service/src/settings/webhooks/transport.rs
@@ -1,0 +1,515 @@
+use futures::future::BoxFuture;
+use futures::FutureExt;
+use reqwest::header::HeaderMap;
+use serde::Serialize;
+use std::sync::OnceLock;
+use std::time::Duration;
+use tracing::trace;
+
+pub struct WebhookResponse {
+    pub headers: HeaderMap,
+    pub body: String,
+    pub success: bool,
+    pub status_code: Option<u16>,
+}
+
+pub struct ReqwestWebhookClient {
+    client: reqwest::Client,
+}
+
+impl ReqwestWebhookClient {
+    pub fn new(timeout: Duration) -> anyhow::Result<Self> {
+        let client = reqwest::Client::builder()
+            .timeout(timeout)
+            .build()
+            .map_err(|e| anyhow::anyhow!("failed to build reqwest client: {e}"))?;
+
+        Ok(Self { client })
+    }
+}
+
+pub trait WebhookHttpClient: Send + Sync {
+    fn post_json<'a>(
+        &'a self,
+        url: &'a str,
+        payload: &'a serde_json::Value,
+    ) -> BoxFuture<'a, anyhow::Result<WebhookResponse>>;
+}
+
+pub trait WebhookSleeper: Send + Sync {
+    fn sleep<'a>(&'a self, duration: Duration) -> BoxFuture<'a, ()>;
+}
+
+pub trait WebhookClock: Send + Sync {
+    fn now(&self) -> u64;
+}
+
+pub struct TokioWebhookSleeper;
+
+pub struct UtcWebhookClock;
+
+pub struct WebhookSender<C, S, N> {
+    client: C,
+    sleeper: S,
+    clock: N,
+}
+
+impl<C, S, N> WebhookSender<C, S, N>
+where
+    C: WebhookHttpClient,
+    S: WebhookSleeper,
+    N: WebhookClock,
+{
+    pub fn new(client: C, sleeper: S, clock: N) -> Self {
+        Self {
+            client,
+            sleeper,
+            clock,
+        }
+    }
+
+    pub async fn send_json<T>(&self, url: &str, messages: &[T], retries: u8) -> anyhow::Result<()>
+    where
+        T: Serialize,
+    {
+        let messages = messages
+            .iter()
+            .map(serde_json::to_value)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let max_retries = retries;
+        let mut retries = retries;
+        let mut index = 0;
+
+        while index < messages.len() {
+            let message = &messages[index];
+
+            let response = match self.client.post_json(url, message).await {
+                Ok(resp) => resp,
+                Err(err) => {
+                    if retries == 0 {
+                        return Err(err);
+                    }
+
+                    let backoff = Duration::from_secs(2u64.pow((max_retries - retries) as u32));
+                    trace!(
+                        "network error, retrying in {} seconds: {err}",
+                        backoff.as_secs()
+                    );
+                    self.sleeper.sleep(backoff).await;
+                    retries -= 1;
+                    continue;
+                }
+            };
+
+            if response.success {
+                index += 1;
+                retries = max_retries;
+                continue;
+            }
+
+            if let Some(wait) = self.retry_delay(&response.headers) {
+                if retries == 0 {
+                    return Err(anyhow::anyhow!(
+                        "failed to send webhook, retries exhausted: {}",
+                        response.body
+                    ));
+                }
+
+                trace!("rate limited, waiting for {} seconds", wait.as_secs());
+
+                self.sleeper.sleep(wait).await;
+                retries -= 1;
+                continue;
+            }
+
+            let is_server_error = response
+                .status_code
+                .is_some_and(|code| (500..600).contains(&code));
+
+            if is_server_error && retries > 0 {
+                let backoff = Duration::from_secs(2u64.pow((max_retries - retries) as u32));
+                trace!(
+                    "server error {}, retrying in {} seconds",
+                    response.status_code.unwrap_or(0),
+                    backoff.as_secs()
+                );
+                self.sleeper.sleep(backoff).await;
+                retries -= 1;
+                continue;
+            }
+
+            return Err(anyhow::anyhow!("failed to send webhook: {}", response.body));
+        }
+
+        Ok(())
+    }
+
+    fn retry_delay(&self, headers: &HeaderMap) -> Option<Duration> {
+        if let Some(retry_after) = headers.get("Retry-After") {
+            let retry_after = retry_after.to_str().ok()?;
+            let retry_after = retry_after.parse::<u64>().ok()?;
+
+            return Some(Duration::from_secs(retry_after));
+        }
+
+        if let Some(reset) = headers.get("X-RateLimit-Reset") {
+            let reset = reset.to_str().ok()?;
+            let reset = reset.parse::<u64>().ok()?;
+            let now = self.clock.now();
+
+            if reset > now {
+                return Some(Duration::from_secs(reset - now));
+            }
+        }
+
+        None
+    }
+}
+
+impl WebhookHttpClient for ReqwestWebhookClient {
+    fn post_json<'a>(
+        &'a self,
+        url: &'a str,
+        payload: &'a serde_json::Value,
+    ) -> BoxFuture<'a, anyhow::Result<WebhookResponse>> {
+        async move {
+            let response = self
+                .client
+                .post(url)
+                .json(&payload)
+                .send()
+                .await
+                .map_err(|e| anyhow::anyhow!(e))?;
+
+            let headers = response.headers().clone();
+            let status_code = response.status().as_u16();
+            let success = response.status().is_success();
+            let body = if success {
+                String::new()
+            } else {
+                response
+                    .text()
+                    .await
+                    .unwrap_or_else(|_| "no body".to_string())
+            };
+
+            Ok(WebhookResponse {
+                headers,
+                body,
+                success,
+                status_code: Some(status_code),
+            })
+        }
+        .boxed()
+    }
+}
+
+impl WebhookSleeper for TokioWebhookSleeper {
+    fn sleep<'a>(&'a self, duration: Duration) -> BoxFuture<'a, ()> {
+        async move {
+            tokio::time::sleep(duration).await;
+        }
+        .boxed()
+    }
+}
+
+impl WebhookClock for UtcWebhookClock {
+    fn now(&self) -> u64 {
+        chrono::Utc::now().timestamp() as u64
+    }
+}
+
+type SharedSender = WebhookSender<ReqwestWebhookClient, TokioWebhookSleeper, UtcWebhookClock>;
+
+static SHARED_SENDER: OnceLock<Result<SharedSender, String>> = OnceLock::new();
+
+/// Returns a reference to the shared webhook sender, initialising it on first call.
+///
+/// The `timeout` parameter is only used during the first initialisation.
+/// Subsequent calls return the same sender regardless of the timeout value passed.
+pub fn shared_sender(timeout: Duration) -> anyhow::Result<&'static SharedSender> {
+    SHARED_SENDER
+        .get_or_init(|| {
+            ReqwestWebhookClient::new(timeout)
+                .map(|client| WebhookSender::new(client, TokioWebhookSleeper, UtcWebhookClock))
+                .map_err(|e| e.to_string())
+        })
+        .as_ref()
+        .map_err(|e| anyhow::anyhow!("{e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::FutureExt;
+    use reqwest::header::{HeaderValue, CONTENT_TYPE};
+    use std::collections::VecDeque;
+    use std::sync::{Arc, Mutex};
+
+    enum FakeResponse {
+        Ok(WebhookResponse),
+        Err(String),
+    }
+
+    #[derive(Clone)]
+    struct FakeClient {
+        responses: Arc<Mutex<VecDeque<FakeResponse>>>,
+        requests: Arc<Mutex<Vec<serde_json::Value>>>,
+    }
+
+    impl FakeClient {
+        fn new(responses: Vec<WebhookResponse>) -> Self {
+            Self {
+                responses: Arc::new(Mutex::new(
+                    responses.into_iter().map(FakeResponse::Ok).collect(),
+                )),
+                requests: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        fn with_results(responses: Vec<FakeResponse>) -> Self {
+            Self {
+                responses: Arc::new(Mutex::new(responses.into())),
+                requests: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        fn requests(&self) -> Vec<serde_json::Value> {
+            self.requests.lock().unwrap().clone()
+        }
+    }
+
+    impl WebhookHttpClient for FakeClient {
+        fn post_json<'a>(
+            &'a self,
+            _url: &'a str,
+            payload: &'a serde_json::Value,
+        ) -> BoxFuture<'a, anyhow::Result<WebhookResponse>> {
+            async move {
+                self.requests.lock().unwrap().push(payload.clone());
+                match self
+                    .responses
+                    .lock()
+                    .unwrap()
+                    .pop_front()
+                    .expect("missing fake response")
+                {
+                    FakeResponse::Ok(resp) => Ok(resp),
+                    FakeResponse::Err(msg) => Err(anyhow::anyhow!(msg)),
+                }
+            }
+            .boxed()
+        }
+    }
+
+    #[derive(Default)]
+    struct FakeSleeper {
+        sleeps: Mutex<Vec<Duration>>,
+    }
+
+    impl FakeSleeper {
+        fn sleeps(&self) -> Vec<Duration> {
+            self.sleeps.lock().unwrap().clone()
+        }
+    }
+
+    impl WebhookSleeper for FakeSleeper {
+        fn sleep<'a>(&'a self, duration: Duration) -> BoxFuture<'a, ()> {
+            async move {
+                self.sleeps.lock().unwrap().push(duration);
+            }
+            .boxed()
+        }
+    }
+
+    struct FakeClock {
+        now: u64,
+    }
+
+    impl WebhookClock for FakeClock {
+        fn now(&self) -> u64 {
+            self.now
+        }
+    }
+
+    fn success_response() -> WebhookResponse {
+        let mut headers = HeaderMap::new();
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+
+        WebhookResponse {
+            headers,
+            body: String::new(),
+            success: true,
+            status_code: Some(200),
+        }
+    }
+
+    fn rate_limited_response(reset: u64) -> WebhookResponse {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "X-RateLimit-Reset",
+            HeaderValue::from_str(&reset.to_string()).unwrap(),
+        );
+
+        WebhookResponse {
+            headers,
+            body: "rate limited".to_string(),
+            success: false,
+            status_code: Some(429),
+        }
+    }
+
+    fn retry_after_response(retry_after: u64) -> WebhookResponse {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "Retry-After",
+            HeaderValue::from_str(&retry_after.to_string()).unwrap(),
+        );
+
+        WebhookResponse {
+            headers,
+            body: "rate limited".to_string(),
+            success: false,
+            status_code: Some(429),
+        }
+    }
+
+    fn server_error_response() -> WebhookResponse {
+        WebhookResponse {
+            headers: HeaderMap::new(),
+            body: "Internal Server Error".to_string(),
+            success: false,
+            status_code: Some(500),
+        }
+    }
+
+    #[tokio::test]
+    async fn send_json_retries_only_unsent_messages_after_rate_limit_reset() {
+        let client = FakeClient::new(vec![
+            success_response(),
+            rate_limited_response(105),
+            success_response(),
+        ]);
+        let sleeper = FakeSleeper::default();
+        let sender = WebhookSender::new(client.clone(), sleeper, FakeClock { now: 100 });
+        let messages = [
+            serde_json::json!({ "id": 1 }),
+            serde_json::json!({ "id": 2 }),
+        ];
+
+        sender
+            .send_json("https://example.com/webhook", &messages, 1)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            client.requests(),
+            vec![
+                messages[0].clone(),
+                messages[1].clone(),
+                messages[1].clone()
+            ]
+        );
+        assert_eq!(sender.sleeper.sleeps(), vec![Duration::from_secs(5)]);
+    }
+
+    #[tokio::test]
+    async fn send_json_retries_after_standard_retry_after_header() {
+        let client = FakeClient::new(vec![retry_after_response(3), success_response()]);
+        let sleeper = FakeSleeper::default();
+        let sender = WebhookSender::new(client.clone(), sleeper, FakeClock { now: 100 });
+        let messages = [serde_json::json!({ "id": 1 })];
+
+        sender
+            .send_json("https://example.com/webhook", &messages, 1)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            client.requests(),
+            vec![messages[0].clone(), messages[0].clone()]
+        );
+        assert_eq!(sender.sleeper.sleeps(), vec![Duration::from_secs(3)]);
+    }
+
+    #[tokio::test]
+    async fn send_json_returns_retries_exhausted_when_rate_limit_persists() {
+        let client = FakeClient::new(vec![rate_limited_response(105)]);
+        let sender = WebhookSender::new(client, FakeSleeper::default(), FakeClock { now: 100 });
+        let messages = [serde_json::json!({ "id": 1 })];
+
+        let error = sender
+            .send_json("https://example.com/webhook", &messages, 0)
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "failed to send webhook, retries exhausted: rate limited"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_json_retries_on_5xx_with_exponential_backoff() {
+        let client = FakeClient::new(vec![server_error_response(), success_response()]);
+        let sleeper = FakeSleeper::default();
+        let sender = WebhookSender::new(client.clone(), sleeper, FakeClock { now: 100 });
+        let messages = [serde_json::json!({ "id": 1 })];
+
+        sender
+            .send_json("https://example.com/webhook", &messages, 2)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            client.requests(),
+            vec![messages[0].clone(), messages[0].clone()]
+        );
+        // max_retries=2, retries=2 on first failure: backoff = 2^(2-2) = 1s
+        assert_eq!(sender.sleeper.sleeps(), vec![Duration::from_secs(1)]);
+    }
+
+    #[tokio::test]
+    async fn send_json_retries_on_network_error_with_exponential_backoff() {
+        let client = FakeClient::with_results(vec![
+            FakeResponse::Err("connection reset".to_string()),
+            FakeResponse::Ok(success_response()),
+        ]);
+        let sleeper = FakeSleeper::default();
+        let sender = WebhookSender::new(client.clone(), sleeper, FakeClock { now: 100 });
+        let messages = [serde_json::json!({ "id": 1 })];
+
+        sender
+            .send_json("https://example.com/webhook", &messages, 2)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            client.requests(),
+            vec![messages[0].clone(), messages[0].clone()]
+        );
+        // max_retries=2, retries=2 on first failure: backoff = 2^(2-2) = 1s
+        assert_eq!(sender.sleeper.sleeps(), vec![Duration::from_secs(1)]);
+    }
+
+    #[tokio::test]
+    async fn send_json_gives_up_after_retries_exhausted_on_5xx() {
+        let client = FakeClient::new(vec![server_error_response(), server_error_response()]);
+        let sleeper = FakeSleeper::default();
+        let sender = WebhookSender::new(client, sleeper, FakeClock { now: 100 });
+        let messages = [serde_json::json!({ "id": 1 })];
+
+        let error = sender
+            .send_json("https://example.com/webhook", &messages, 1)
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "failed to send webhook: Internal Server Error"
+        );
+        // max_retries=1, retries=1 on first failure: backoff = 2^(1-1) = 1s
+        assert_eq!(sender.sleeper.sleeps(), vec![Duration::from_secs(1)]);
+    }
+}

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -21,9 +21,15 @@
   #     to: /new/tv
   
 # webhooks:
-  # discord:
-  #   type: "discord"
-  #   url: "https://discord.com/api/webhooks/1234567890/aBcDeFgHiJkLmNoPqRsTuVwXyZ"
+#   discord:
+#     type: "discord"
+#     url: "https://discord.com/api/webhooks/1234567890/aBcDeFgHiJkLmNoPqRsTuVwXyZ"
+#   hookshot:
+#     type: "hookshot"
+#     url: "https://matrix.example.com/_matrix/hookshot/webhook/aBcDeFgHiJkLmNoPqRsTuVwXyZ"
+#   json:
+#     type: "json"
+#     url: "https://example.com/webhooks/autopulse"
 
 # targets:
   # plex:


### PR DESCRIPTION
# Description

Add `hookshot` and `json` webhook types so autopulse can send notifications to Matrix Hookshot or any generic JSON webhook endpoint. This also extracts shared webhook transport and retry handling so Discord, Hookshot, and generic JSON webhooks use the same delivery path.

Closes #484

## Type of change

- [ ] Bug (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (addition or change to documentation)