### PR TITLE
chore(release): v1.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,7 +277,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autopulse"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "autopulse-database",
@@ -291,7 +291,7 @@ dependencies = [
 
 [[package]]
 name = "autopulse-database"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "autopulse-utils",
@@ -308,7 +308,7 @@ dependencies = [
 
 [[package]]
 name = "autopulse-server"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "actix-web",
  "actix-web-httpauth",
@@ -325,7 +325,7 @@ dependencies = [
 
 [[package]]
 name = "autopulse-service"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "autopulse-database",
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "autopulse-utils"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 version.workspace = true
 
 [workspace.package]
-version = "1.5.0"
+version = "1.6.0"
 
 [features]
 vendored = ["autopulse-service/vendored", "autopulse-database/vendored"]


### PR DESCRIPTION
## Release v1.6.0

Merging this PR will automatically create GitHub release `v1.6.0`.

**Full Changelog**: https://github.com/dan-online/autopulse/compare/v1.5.0...v1.6.0