### PR TITLE
fix(triggers): handle Sonarr batch import payloads

### DIFF
--- a/crates/service/src/settings/triggers/lidarr.rs
+++ b/crates/service/src/settings/triggers/lidarr.rs
@@ -80,6 +80,8 @@ pub enum LidarrRequest {
     AlbumDelete { artist: Artist },
     #[serde(rename = "Test")]
     Test,
+    #[serde(other)]
+    Other,
 }
 
 impl TriggerRequest for LidarrRequest {
@@ -107,7 +109,7 @@ impl TriggerRequest for LidarrRequest {
             Self::ArtistDelete { artist } | Self::AlbumDelete { artist } => {
                 vec![(artist.path.clone(), false)]
             }
-            Self::Test => vec![],
+            Self::Test | Self::Other => vec![],
         }
     }
 }

--- a/crates/service/src/settings/triggers/radarr.rs
+++ b/crates/service/src/settings/triggers/radarr.rs
@@ -72,6 +72,8 @@ pub enum RadarrRequest {
     Rename { movie: Movie },
     #[serde(rename = "Test")]
     Test,
+    #[serde(other)]
+    Other,
 }
 
 impl TriggerRequest for RadarrRequest {
@@ -108,7 +110,7 @@ impl TriggerRequest for RadarrRequest {
 
                 paths
             }
-            Self::Test => vec![],
+            Self::Test | Self::Other => vec![],
         }
     }
 }

--- a/crates/service/src/settings/triggers/readarr.rs
+++ b/crates/service/src/settings/triggers/readarr.rs
@@ -80,6 +80,8 @@ pub enum ReadarrRequest {
     BookFileDelete { book_file: BookFile },
     #[serde(rename = "Test")]
     Test,
+    #[serde(other)]
+    Other,
 }
 
 impl TriggerRequest for ReadarrRequest {
@@ -108,7 +110,7 @@ impl TriggerRequest for ReadarrRequest {
             Self::BookFileDelete { book_file } => {
                 vec![(book_file.path.clone(), false)]
             }
-            Self::Test => vec![],
+            Self::Test | Self::Other => vec![],
         }
     }
 }

--- a/crates/service/src/settings/triggers/sonarr.rs
+++ b/crates/service/src/settings/triggers/sonarr.rs
@@ -63,7 +63,11 @@ pub enum SonarrRequest {
     #[serde(rename = "Download")]
     #[serde(rename_all = "camelCase")]
     Download {
-        episode_file: EpisodeFile,
+        /// Single file import (WebhookImportPayload)
+        episode_file: Option<EpisodeFile>,
+        /// Batch import (WebhookImportCompletePayload) - Sonarr sends `episodeFiles` (plural)
+        #[serde(default)]
+        episode_files: Vec<EpisodeFile>,
         #[serde(default)]
         deleted_files: Vec<EpisodeFile>,
         series: Series,
@@ -85,6 +89,8 @@ pub enum SonarrRequest {
     },
     #[serde(rename = "Test")]
     Test,
+    #[serde(other)]
+    Other,
 }
 
 impl TriggerRequest for SonarrRequest {
@@ -116,10 +122,19 @@ impl TriggerRequest for SonarrRequest {
             Self::SeriesDelete { series } => vec![(series.path.clone(), false)],
             Self::Download {
                 episode_file,
+                episode_files,
                 series,
                 deleted_files,
             } => {
-                let mut paths = vec![(join_path(&series.path, &episode_file.relative_path), true)];
+                let mut paths: Vec<(String, bool)> = vec![];
+
+                if let Some(ef) = episode_file {
+                    paths.push((join_path(&series.path, &ef.relative_path), true));
+                }
+
+                for ef in episode_files {
+                    paths.push((join_path(&series.path, &ef.relative_path), true));
+                }
 
                 for file in deleted_files {
                     paths.push((join_path(&series.path, &file.relative_path), false));
@@ -127,7 +142,7 @@ impl TriggerRequest for SonarrRequest {
 
                 paths
             }
-            Self::Test => vec![],
+            Self::Test | Self::Other => vec![],
         }
     }
 }

--- a/crates/service/src/tests/triggers/sonarr.rs
+++ b/crates/service/src/tests/triggers/sonarr.rs
@@ -154,7 +154,10 @@ mod tests {
             ..
         } = sonarr_request.clone()
         {
-            assert_eq!(episode_file.relative_path, "Season 1/Westworld.S01E01.mkv");
+            assert_eq!(
+                episode_file.unwrap().relative_path,
+                "Season 1/Westworld.S01E01.mkv"
+            );
             assert_eq!(series.path, "/TV/Westworld");
             assert_eq!(
                 sonarr_request.paths(),
@@ -166,5 +169,60 @@ mod tests {
         } else {
             panic!("Unexpected variant");
         }
+    }
+
+    #[test]
+    fn test_from_json_download_import_complete() {
+        let json = serde_json::json!({
+            "eventType": "Download",
+            "episodeFiles": [
+                { "relativePath": "Season 1/Westworld.S01E01.mkv" },
+                { "relativePath": "Season 1/Westworld.S01E02.mkv" }
+            ],
+            "series": {
+                "path": "/TV/Westworld"
+            }
+        });
+
+        let sonarr_request = SonarrRequest::from_json(json).unwrap();
+
+        if let SonarrRequest::Download {
+            episode_file,
+            episode_files,
+            series,
+            ..
+        } = sonarr_request.clone()
+        {
+            assert!(episode_file.is_none());
+            assert_eq!(episode_files.len(), 2);
+            assert_eq!(series.path, "/TV/Westworld");
+            assert_eq!(
+                sonarr_request.paths(),
+                vec![
+                    (
+                        "/TV/Westworld/Season 1/Westworld.S01E01.mkv".to_string(),
+                        true
+                    ),
+                    (
+                        "/TV/Westworld/Season 1/Westworld.S01E02.mkv".to_string(),
+                        true
+                    )
+                ]
+            );
+        } else {
+            panic!("Unexpected variant");
+        }
+    }
+
+    #[test]
+    fn test_from_json_unknown_event_type() {
+        let json = serde_json::json!({
+            "eventType": "Grab",
+            "series": { "path": "/TV/Westworld" }
+        });
+
+        let sonarr_request = SonarrRequest::from_json(json).unwrap();
+        assert!(matches!(sonarr_request, SonarrRequest::Other));
+        assert_eq!(sonarr_request.paths(), vec![]);
     }
 }

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772773019,
-        "narHash": "sha256-E1bxHxNKfDoQUuvriG71+f+s/NT0qWkImXsYZNFFfCs=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772852295,
-        "narHash": "sha256-3FB/WzLZSiU2Mc50C9q9VXU1LRUZbsU6UHKmZG1C+hU=",
+        "lastModified": 1779074409,
+        "narHash": "sha256-6aXy8Ga41iLVM8ibddFU1O5+wYWcBGNEfZzZuL91eIc=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "c10801f59c68e14c308aea8fa6b0b3d81d43c61e",
+        "rev": "2a77b5b1dc952f214e8102acdef1622b68515560",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Description

Sonarr's `ImportComplete` sends `episodeFiles` (plural) instead of `episodeFile`, which failed deserialization. Also adds catch-all variants for unhandled event types across all *arr triggers.

Closes #541

## Type of change

- [x] Bug (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (addition or change to documentation)