### PR TITLE
feat(infra): add Unraid Community Apps template

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ RUN apk add --no-cache \
 
 RUN addgroup -g 1000 autopulse && \
     adduser -D -u 1000 -G autopulse -h /config autopulse && \
-    mkdir -p /app && \
-    chown autopulse:autopulse /app /config
+    mkdir -p /app /data && \
+    chown autopulse:autopulse /app /config /data
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,24 @@ The easiest way to get started with autopulse is to use the provided docker imag
 
 > All images are multi-arch and support `linux/amd64`, `linux/arm64`, however -amd64 and -arm64 suffixes can be used to specify the architecture
 
+#### Unraid
+
+An Unraid Community Apps template lives in [`unraid/autopulse.xml`](unraid/autopulse.xml).
+
+Once autopulse is listed in Community Apps, open the **Apps** tab in Unraid, search for `autopulse`, and click **Install**. Until then, install it as a private Community App:
+
+1. Make sure Community Applications is installed (it ships with Unraid via the Apps tab).
+2. SSH to your Unraid server and run:
+
+   ```bash
+   mkdir -p /boot/config/plugins/community.applications/private/autopulse
+   wget -O /boot/config/plugins/community.applications/private/autopulse/autopulse.xml \
+     https://raw.githubusercontent.com/dan-online/autopulse/main/unraid/autopulse.xml
+   ```
+
+3. In the WebUI, open **Apps** and select **Private apps** from the left sidebar, then click **Install** on autopulse.
+4. Adjust the **Media share** path and change **AUTOPULSE__AUTH__PASSWORD** from the default `change-me` before clicking Apply.
+
 #### Compose
 
 Docker Compose files for both SQLite and Postgres are provided in the [example](https://github.com/dan-online/autopulse/blob/main/example)

--- a/ca_profile.xml
+++ b/ca_profile.xml
@@ -1,0 +1,11 @@
+<CommunityApplications>
+  <Profile>
+    autopulse is an automated service that bridges media organizers like Sonarr,
+    Radarr, Lidarr, and Readarr with media servers like Plex, Jellyfin, and Emby.
+    This repository contains the autopulse Community Apps template and project
+    source. Use the GitHub issue tracker for support.
+  </Profile>
+  <Icon>https://raw.githubusercontent.com/dan-online/autopulse/main/assets/logo.webp</Icon>
+  <WebPage>https://github.com/dan-online/autopulse</WebPage>
+  <Forum>https://github.com/dan-online/autopulse/issues</Forum>
+</CommunityApplications>

--- a/crates/database/src/conn.rs
+++ b/crates/database/src/conn.rs
@@ -7,7 +7,9 @@ use diesel::{Connection, RunQueryDsl};
 use diesel::{SaveChangesDsl, SelectableHelper};
 use diesel_migrations::{embed_migrations, EmbeddedMigrations, MigrationHarness};
 use serde::Deserialize;
+use std::fs::OpenOptions;
 use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::{info, warn};
 
 #[doc(hidden)]
@@ -133,6 +135,31 @@ impl AnyConnection {
                     format!("failed to create database directory: {}", parent.display())
                 })?;
             }
+
+            let timestamp = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|duration| duration.as_nanos())
+                .unwrap_or_default();
+            let probe = parent.join(format!(
+                ".autopulse-db-write-test-{}-{timestamp}",
+                std::process::id()
+            ));
+
+            let file = OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&probe)
+                .with_context(|| {
+                    format!("database directory is not writable: {}", parent.display())
+                })?;
+            drop(file);
+
+            std::fs::remove_file(&probe).with_context(|| {
+                format!(
+                    "failed to remove database directory write test file: {}",
+                    probe.display()
+                )
+            })?;
         }
 
         Ok(())
@@ -290,6 +317,28 @@ mod tests {
 
         let result = AnyConnection::pre_init(&url);
         assert!(result.is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_pre_init_existing_unwritable_directory_fails_with_context() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempdir().unwrap();
+        let subdir = tmp.path().join("readonly");
+        fs::create_dir(&subdir).unwrap();
+        fs::set_permissions(&subdir, fs::Permissions::from_mode(0o555)).unwrap();
+
+        let db_path = subdir.join("test.db");
+        let url = format!("sqlite://{}", db_path.display());
+
+        let result = AnyConnection::pre_init(&url);
+
+        fs::set_permissions(&subdir, fs::Permissions::from_mode(0o755)).unwrap();
+        let err = result.expect_err("unwritable database directory should fail pre-init");
+        let err = err.to_string();
+        assert!(err.contains("database directory is not writable"));
+        assert!(err.contains(&subdir.display().to_string()));
     }
 
     #[test]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -26,8 +26,8 @@ if [ "$(id -u)" = "0" ]; then
             usermod -o -u "$PUID" autopulse
         fi
 
-        # Fix ownership of app and config directories
-        chown -R autopulse:autopulse /config /app 2>/dev/null || true
+        # Fix ownership of app, config, and data directories
+        chown -R autopulse:autopulse /config /app /data 2>/dev/null || true
 
         # Set user environment variables that su-exec doesn't provide
         # Use env to ensure these are passed through exec

--- a/unraid/autopulse.xml
+++ b/unraid/autopulse.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0"?>
+<Container version="2">
+  <Name>autopulse</Name>
+  <Repository>ghcr.io/dan-online/autopulse:stable</Repository>
+  <Registry>https://github.com/dan-online/autopulse/pkgs/container/autopulse</Registry>
+  <Network>bridge</Network>
+  <MyIP/>
+  <Shell>sh</Shell>
+  <Privileged>false</Privileged>
+  <Support>https://github.com/dan-online/autopulse/issues</Support>
+  <Project>https://github.com/dan-online/autopulse</Project>
+  <Overview>autopulse is a lightweight service that updates media servers like Plex and Jellyfin based on notifications from media organizers like Sonarr, Radarr, Lidarr, and Readarr. Instead of triggering full library scans, autopulse sends targeted refresh requests for the specific items that changed.</Overview>
+  <Category>MediaApp:Other Tools:Utilities</Category>
+  <WebUI>http://[IP]:[PORT:2875]/</WebUI>
+  <TemplateURL>https://raw.githubusercontent.com/dan-online/autopulse/main/unraid/autopulse.xml</TemplateURL>
+  <Icon>https://raw.githubusercontent.com/dan-online/autopulse/main/assets/logo.webp</Icon>
+  <ExtraParams/>
+  <PostArgs/>
+  <CPUset/>
+  <DonateText/>
+  <DonateLink/>
+  <GitHub>https://github.com/dan-online/autopulse</GitHub>
+  <ReadMe>https://github.com/dan-online/autopulse#readme</ReadMe>
+  <ExtraSearchTerms>sonarr radarr lidarr readarr plex jellyfin emby webhook arr</ExtraSearchTerms>
+  <License>MIT</License>
+  <Requires>**Change AUTOPULSE__AUTH__PASSWORD from the default `change-me`** before exposing this service to other hosts on your network.</Requires>
+  <Description>autopulse is a lightweight service that updates media servers like Plex and Jellyfin based on notifications from media organizers like Sonarr, Radarr, Lidarr, and Readarr. Instead of triggering full library scans, autopulse sends targeted refresh requests for the specific items that changed.
+
+Documentation: https://autopulse.dancodes.online/
+
+After install, point Sonarr/Radarr/etc. webhooks at http://&lt;UNRAID_IP&gt;:2875/triggers/&lt;trigger_name&gt; using the basic-auth credentials below.</Description>
+  <Networking>
+    <Mode>bridge</Mode>
+    <Publish>
+      <Port>
+        <HostPort>2875</HostPort>
+        <ContainerPort>2875</ContainerPort>
+        <Protocol>tcp</Protocol>
+      </Port>
+    </Publish>
+  </Networking>
+  <Data>
+    <Volume>
+      <HostDir>/mnt/user/appdata/autopulse</HostDir>
+      <ContainerDir>/data</ContainerDir>
+      <Mode>rw</Mode>
+    </Volume>
+    <Volume>
+      <HostDir>/mnt/user/media</HostDir>
+      <ContainerDir>/media</ContainerDir>
+      <Mode>ro</Mode>
+    </Volume>
+  </Data>
+  <Environment>
+    <Variable>
+      <Value>sqlite:///data/autopulse.db</Value>
+      <Name>AUTOPULSE__APP__DATABASE_URL</Name>
+      <Mode/>
+    </Variable>
+    <Variable>
+      <Value>admin</Value>
+      <Name>AUTOPULSE__AUTH__USERNAME</Name>
+      <Mode/>
+    </Variable>
+    <Variable>
+      <Value>change-me</Value>
+      <Name>AUTOPULSE__AUTH__PASSWORD</Name>
+      <Mode/>
+    </Variable>
+    <Variable>
+      <Value>info</Value>
+      <Name>AUTOPULSE__APP__LOG_LEVEL</Name>
+      <Mode/>
+    </Variable>
+  </Environment>
+  <Config Name="WebUI port" Target="2875" Default="2875" Mode="tcp" Description="HTTP port for the autopulse API and UI" Type="Port" Display="always" Required="true" Mask="false">2875</Config>
+  <Config Name="App data" Target="/data" Default="/mnt/user/appdata/autopulse" Mode="rw" Description="Holds autopulse.db (SQLite) and the session key" Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/autopulse</Config>
+  <Config Name="Media share" Target="/media" Default="/mnt/user/media" Mode="ro" Description="Read-only mount of your media library. autopulse only reads file paths, so :ro is intentional. Mirror the paths your Sonarr/Radarr triggers will report." Type="Path" Display="always" Required="true" Mask="false">/mnt/user/media</Config>
+  <Config Name="Database URL" Target="AUTOPULSE__APP__DATABASE_URL" Default="sqlite:///data/autopulse.db" Mode="" Description="Connection string. For Postgres use postgres://user:pass@host/db" Type="Variable" Display="advanced" Required="true" Mask="false">sqlite:///data/autopulse.db</Config>
+  <Config Name="Basic-auth username" Target="AUTOPULSE__AUTH__USERNAME" Default="admin" Mode="" Description="Basic-auth username. Change from the default before exposing." Type="Variable" Display="always" Required="true" Mask="false">admin</Config>
+  <Config Name="Basic-auth password" Target="AUTOPULSE__AUTH__PASSWORD" Default="change-me" Mode="" Description="Basic-auth password. Change from the default before exposing." Type="Variable" Display="always" Required="true" Mask="true">change-me</Config>
+  <Config Name="Log level" Target="AUTOPULSE__APP__LOG_LEVEL" Default="info|trace|debug|warn|error" Mode="" Description="Log verbosity" Type="Variable" Display="advanced" Required="false" Mask="false">info</Config>
+</Container>

--- a/unraid/autopulse.xml
+++ b/unraid/autopulse.xml
@@ -72,10 +72,22 @@ After install, point Sonarr/Radarr/etc. webhooks at http://&lt;UNRAID_IP&gt;:287
       <Name>AUTOPULSE__APP__LOG_LEVEL</Name>
       <Mode/>
     </Variable>
+    <Variable>
+      <Value>99</Value>
+      <Name>PUID</Name>
+      <Mode/>
+    </Variable>
+    <Variable>
+      <Value>100</Value>
+      <Name>PGID</Name>
+      <Mode/>
+    </Variable>
   </Environment>
   <Config Name="WebUI port" Target="2875" Default="2875" Mode="tcp" Description="HTTP port for the autopulse API and UI" Type="Port" Display="always" Required="true" Mask="false">2875</Config>
   <Config Name="App data" Target="/data" Default="/mnt/user/appdata/autopulse" Mode="rw" Description="Holds autopulse.db (SQLite) and the session key" Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/autopulse</Config>
   <Config Name="Media share" Target="/media" Default="/mnt/user/media" Mode="ro" Description="Read-only mount of your media library. autopulse only reads file paths, so :ro is intentional. Mirror the paths your Sonarr/Radarr triggers will report." Type="Path" Display="always" Required="true" Mask="false">/mnt/user/media</Config>
+  <Config Name="User ID" Target="PUID" Default="99" Mode="" Description="Container user id. Unraid appdata is usually owned by nobody (99)." Type="Variable" Display="advanced" Required="true" Mask="false">99</Config>
+  <Config Name="Group ID" Target="PGID" Default="100" Mode="" Description="Container group id. Unraid appdata is usually owned by users (100)." Type="Variable" Display="advanced" Required="true" Mask="false">100</Config>
   <Config Name="Database URL" Target="AUTOPULSE__APP__DATABASE_URL" Default="sqlite:///data/autopulse.db" Mode="" Description="Connection string. For Postgres use postgres://user:pass@host/db" Type="Variable" Display="advanced" Required="true" Mask="false">sqlite:///data/autopulse.db</Config>
   <Config Name="Basic-auth username" Target="AUTOPULSE__AUTH__USERNAME" Default="admin" Mode="" Description="Basic-auth username. Change from the default before exposing." Type="Variable" Display="always" Required="true" Mask="false">admin</Config>
   <Config Name="Basic-auth password" Target="AUTOPULSE__AUTH__PASSWORD" Default="change-me" Mode="" Description="Basic-auth password. Change from the default before exposing." Type="Variable" Display="always" Required="true" Mask="true">change-me</Config>


### PR DESCRIPTION
# Description

Adds an Unraid Community Apps XML template at `unraid/autopulse.xml` plus README install steps so Unraid users can deploy autopulse via the Apps tab as a private app.

~**BLOCKED:** needs validating on a real Unraid server before merge.~

Resolves #70 

## Type of change

- [ ] Bug (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (addition or change to documentation)