### PR TITLE
fix(triggers): apply rewrite to autoscan dir path

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,39 @@ Default credentials are `admin` / `password` (the same as the API auth). Change 
 
 To serve the UI behind a reverse proxy with a path prefix, set `app.base_path` and have the proxy pass the prefix through (no strip-prefix). UI routes mount under `base_path` server-side. See [`app` settings](https://autopulse.dancodes.online/autopulse_service/settings/app/struct.App.html) for the full list of relevant options.
 
+### Integrations
+
+#### A-Train (Google Drive)
+
+[A-Train](https://github.com/m0glie/a-train) is a small Python service that watches a Google Drive mount and emits autoscan-style notifications. It works with autopulse out of the box using the built-in `autoscan` trigger:
+
+```toml
+# autopulse config.toml
+[triggers.a_train]
+type = "autoscan"
+
+# Map A-Train's view of the file (its mounted gdrive path)
+# to whatever path your media server expects.
+[triggers.a_train.rewrite]
+from = "/mnt/gdrive"
+to = "/media"
+```
+
+```toml
+# a-train config.toml
+[autoscan]
+url = "http://autopulse:2875/triggers/a_train"
+username = "admin"
+password = "your-password"
+
+[drive]
+account = "./service-account.json"
+```
+
+A-Train will POST file events to `/triggers/a_train`; autopulse applies the rewrite, optionally checks the file (`opts.check_path`), then fans out to your configured targets.
+
+> **Why `autoscan` and not `manual`?** The `manual` trigger expects a single `?path=` query parameter on a GET. The `autoscan` trigger accepts the dir-based payload that A-Train sends and is what its `[autoscan]` block is designed for.
+
 ## To-do
 
 - [x] Add more triggers

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -72,5 +72,6 @@ mod tests {
     #[cfg(feature = "sqlite")]
     mod routes {
         mod public_endpoints;
+        mod triggers;
     }
 }

--- a/crates/server/src/routes/triggers.rs
+++ b/crates/server/src/routes/triggers.rs
@@ -180,7 +180,11 @@ async fn trigger_get_inner(
         },
         Trigger::Autoscan(trigger_settings) => match query {
             TriggerQueryParams::Autoscan(query) => {
-                let dir_path = query.dir.clone();
+                let mut dir_path = query.dir.clone();
+
+                if let Some(rewrite) = &trigger_settings.rewrite {
+                    dir_path = rewrite.rewrite_path(dir_path);
+                }
 
                 let new_scan_event = NewScanEvent {
                     event_source: trigger_name.to_owned(),

--- a/crates/server/src/tests/routes/triggers.rs
+++ b/crates/server/src/tests/routes/triggers.rs
@@ -1,0 +1,82 @@
+use crate::routes::triggers::trigger_get;
+use actix_web::{
+    test::{self, TestRequest},
+    web::Data,
+    App,
+};
+use actix_web_httpauth::extractors::basic;
+use autopulse_database::conn::{get_conn, get_pool};
+use autopulse_service::manager::PulseManager;
+use autopulse_service::settings::triggers::autoscan::Autoscan;
+use autopulse_service::settings::triggers::Trigger;
+use autopulse_service::settings::Settings;
+use autopulse_utils::Rewrite;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+// `Rewrite::single` is `#[cfg(test)]`-gated inside autopulse-utils, so build
+// the value via Deserialize to avoid touching the crate's private fields.
+fn rewrite(from: &str, to: &str) -> Rewrite {
+    serde_json::from_value(serde_json::json!({ "from": from, "to": to }))
+        .expect("rewrite JSON should deserialize")
+}
+
+fn test_manager() -> PulseManager {
+    let unique_id = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock should be after unix epoch")
+        .as_nanos();
+    let database_url = format!("sqlite:///tmp/autopulse-server-autoscan-rewrite-{unique_id}.db");
+
+    let mut settings = Settings::default();
+    settings.app.database_url = database_url.clone();
+    settings.triggers.insert(
+        "a_train".to_string(),
+        Trigger::Autoscan(Autoscan {
+            rewrite: Some(rewrite("/downloads", "/media")),
+            ..Default::default()
+        }),
+    );
+
+    let pool = get_pool(&database_url).expect("test database pool should initialize");
+    get_conn(&pool)
+        .expect("test database connection should initialize")
+        .migrate()
+        .expect("test database migrations should apply");
+
+    PulseManager::new(settings, pool)
+}
+
+fn test_auth_header() -> String {
+    Settings::default().auth.to_auth_encoded()
+}
+
+#[actix_web::test]
+async fn autoscan_trigger_applies_rewrite_to_dir() {
+    let manager = test_manager();
+    let app = test::init_service(
+        App::new()
+            .service(trigger_get)
+            .app_data(basic::Config::default().realm("Restricted area"))
+            .app_data(Data::new(manager)),
+    )
+    .await;
+
+    let response = test::call_service(
+        &app,
+        TestRequest::get()
+            .uri("/triggers/a_train?dir=/downloads/show/episode.mkv")
+            .insert_header(("Authorization", test_auth_header()))
+            .to_request(),
+    )
+    .await;
+
+    assert!(
+        response.status().is_success(),
+        "status={}",
+        response.status()
+    );
+
+    let body: serde_json::Value = test::read_body_json(response).await;
+    let path = body["file_path"].as_str().expect("file_path in response");
+    assert_eq!(path, "/media/show/episode.mkv", "rewrite must be applied");
+}

--- a/crates/service/src/settings/triggers/autoscan.rs
+++ b/crates/service/src/settings/triggers/autoscan.rs
@@ -3,7 +3,7 @@ use crate::settings::timer::Timer;
 use crate::settings::triggers::TriggerConfig;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Default)]
 pub struct Autoscan {
     /// Rewrite path
     pub rewrite: Option<Rewrite>,


### PR DESCRIPTION
# Description

The `autoscan` trigger ignored its configured `rewrite`, so A-Train-style `?dir=` events landed in the database with the source path instead of the media-server path. Now the rewrite is applied before the event is created (test added). Also adds a README section showing how to wire A-Train into autopulse via the `autoscan` trigger.

Resolves #262

## Type of change

- [x] Bug (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (addition or change to documentation)