### PR TITLE
fix(log): enable local-time rotation via patched tracing-appender fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3626,8 +3626,7 @@ dependencies = [
 [[package]]
 name = "tracing-appender"
 version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+source = "git+https://github.com/dan-online/tracing.git?rev=76c45b0cedcfbcc71c05da3e528c83a0f42c026f#76c45b0cedcfbcc71c05da3e528c83a0f42c026f"
 dependencies = [
  "crossbeam-channel",
  "symlink",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,10 @@ lto = true
 [workspace]
 members = ["crates/*"]
 
+[patch.crates-io]
+# See workspace.dependencies.tracing-appender for context.
+tracing-appender = { git = "https://github.com/dan-online/tracing.git", rev = "76c45b0cedcfbcc71c05da3e528c83a0f42c026f" }
+
 [workspace.dependencies]
 # Crates
 autopulse-server = { path = "crates/server" }
@@ -56,6 +60,11 @@ serde_json = "1.0.139"
 
 # Tracing
 tracing = "0.1.41"
+# Pinned to dan-online/tracing fork (commit 76c45b0c) which backports
+# upstream PR tokio-rs/tracing#3255 onto v0.2.5, adding the `local-time`
+# feature flag. Drop this patch when the upstream PR merges and a release
+# ships.
+tracing-appender = { version = "0.2.5", features = ["local-time"] }
 
 # Date and time
 chrono = { version = "0.4.38", features = ["serde"] }

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -34,4 +34,4 @@ regex = "1.11.1"
 uuid = { version = "1.14.0", features = ["v4"] }
 
 # Logging
-tracing-appender = "0.2.3"
+tracing-appender = { workspace = true }

--- a/crates/utils/src/logs.rs
+++ b/crates/utils/src/logs.rs
@@ -68,6 +68,11 @@ pub fn setup_logs(
     let registry = tracing_subscriber::registry().with(filter);
 
     if let Some(log_file) = log_file {
+        // `tracing-appender` is pinned to a fork (see workspace Cargo.toml)
+        // that enables a `local-time` feature, making the rolled filename
+        // suffix and rotation boundary track the local timezone instead of
+        // UTC. Without that feature, log filenames would be a day off the
+        // record timestamps inside them (#208).
         let writer = RollingFileAppender::new(
             log_file_rollover.clone(),
             log_file


### PR DESCRIPTION
# Description

Rolled log filenames used UTC even when log entries inside them used the configured local timezone, so the date in the filename didn't match its contents. Pins `tracing-appender` to my fork that rolls in local time until [upstream](https://github.com/tokio-rs/tracing/pull/3255) ships.

Resolves #208

## Type of change

- [x] Bug (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (addition or change to documentation)