### PR TITLE
feat(settings): add trigger and target path filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,9 @@ triggers:
     rewrite:
       from: "/downloads"
       to: "/tvshows"
+    filter:
+      exclude:
+        - "^/tvshows/extras/"
 
   my_radarr:
     type: "radarr"
@@ -243,6 +246,16 @@ targets:
     type: "jellyfin"
     url: "http://jellyfin:8096"
     token: "<your_token>"
+
+  my_audiobookshelf:
+    type: "audiobookshelf"
+    url: "http://audiobookshelf:13378"
+    token: "<your_token>"
+    filter:
+      include:
+        - "^/audiobooks/"
+      exclude:
+        - "/samples/"
 
   my_command:
     type: "command"

--- a/crates/server/src/routes/triggers.rs
+++ b/crates/server/src/routes/triggers.rs
@@ -60,12 +60,21 @@ pub async fn trigger_post(
             let timer = trigger_settings.get_timer(Some(event_name));
 
             let mut scan_events = vec![];
+            let mut queued_paths = vec![];
+
+            let mut excluded_paths: Vec<String> = vec![];
 
             for path in &paths {
                 let (mut path, search) = path.clone();
 
                 if let Some(rewrite) = &rewrite {
                     path = rewrite.rewrite_path(path);
+                }
+
+                if !trigger_settings.should_process_path(&path) {
+                    tracing::trace!("trigger '{trigger_name}' filtered path '{path}'");
+                    excluded_paths.push(path);
+                    continue;
                 }
 
                 let new_scan_event = NewScanEvent {
@@ -87,31 +96,28 @@ pub async fn trigger_post(
                 };
 
                 match manager.add_event(&new_scan_event) {
-                    Ok(scan_event) => scan_events.push(scan_event),
+                    Ok(scan_event) => {
+                        queued_paths.push(path.clone());
+                        scan_events.push(scan_event);
+                    }
                     Err(e) => error!("failed to add event for '{}': {e}", path),
                 }
             }
 
-            manager
-                .webhooks
-                .add_event(
-                    EventType::New,
-                    Some(trigger_name.clone()),
-                    &paths
-                        .clone()
-                        .into_iter()
-                        .map(|p| p.0)
-                        .collect::<Vec<String>>(),
-                )
-                .await;
+            if scan_events.len() + excluded_paths.len() != paths.len() {
+                return Ok(HttpResponse::InternalServerError().body("failed to add all events"));
+            }
+
+            if !queued_paths.is_empty() {
+                manager
+                    .webhooks
+                    .add_event(EventType::New, Some(trigger_name.clone()), &queued_paths)
+                    .await;
+            }
 
             debug_span!("", trigger = &*trigger_name).in_scope(|| {
                 info!("added {} file{}", scan_events.len(), sify(&scan_events));
             });
-
-            if scan_events.len() != paths.len() {
-                return Ok(HttpResponse::InternalServerError().body("failed to add all events"));
-            }
 
             Ok(HttpResponse::Ok().json(scan_events))
         }
@@ -134,6 +140,11 @@ async fn trigger_get_inner(
 
                 if let Some(rewrite) = &trigger_settings.rewrite {
                     file_path = rewrite.rewrite_path(file_path);
+                }
+
+                if !trigger_settings.filter.allows(&file_path) {
+                    tracing::trace!("trigger '{trigger_name}' filtered path '{file_path}'");
+                    return Ok(HttpResponse::NoContent().finish());
                 }
 
                 let new_scan_event = NewScanEvent {
@@ -184,6 +195,11 @@ async fn trigger_get_inner(
 
                 if let Some(rewrite) = &trigger_settings.rewrite {
                     dir_path = rewrite.rewrite_path(dir_path);
+                }
+
+                if !trigger_settings.filter.allows(&dir_path) {
+                    tracing::trace!("trigger '{trigger_name}' filtered path '{dir_path}'");
+                    return Ok(HttpResponse::NoContent().finish());
                 }
 
                 let new_scan_event = NewScanEvent {

--- a/crates/server/src/tests/routes/triggers.rs
+++ b/crates/server/src/tests/routes/triggers.rs
@@ -1,4 +1,4 @@
-use crate::routes::triggers::trigger_get;
+use crate::routes::triggers::{trigger_get, trigger_post};
 use actix_web::{
     test::{self, TestRequest},
     web::Data,
@@ -36,6 +36,15 @@ fn test_manager() -> PulseManager {
             ..Default::default()
         }),
     );
+    settings.triggers.insert(
+        "sonarr".to_string(),
+        serde_json::from_value(serde_json::json!({
+            "type": "sonarr",
+            "rewrite": { "from": "/TV", "to": "/media/tv" },
+            "filter": { "exclude": ["S01E02"] }
+        }))
+        .expect("sonarr trigger JSON should deserialize"),
+    );
 
     let pool = get_pool(&database_url).expect("test database pool should initialize");
     get_conn(&pool)
@@ -44,6 +53,52 @@ fn test_manager() -> PulseManager {
         .expect("test database migrations should apply");
 
     PulseManager::new(settings, pool)
+}
+
+#[actix_web::test]
+async fn webhook_trigger_returns_only_queued_paths_after_filtering() {
+    let manager = test_manager();
+    let app = test::init_service(
+        App::new()
+            .service(trigger_post)
+            .app_data(basic::Config::default().realm("Restricted area"))
+            .app_data(Data::new(manager)),
+    )
+    .await;
+
+    let response = test::call_service(
+        &app,
+        TestRequest::post()
+            .uri("/triggers/sonarr")
+            .insert_header(("Authorization", test_auth_header()))
+            .set_json(serde_json::json!({
+                "eventType": "Download",
+                "episodeFiles": [
+                    { "relativePath": "Season 1/Westworld.S01E01.mkv" },
+                    { "relativePath": "Season 1/Westworld.S01E02.mkv" }
+                ],
+                "series": {
+                    "path": "/TV/Westworld"
+                }
+            }))
+            .to_request(),
+    )
+    .await;
+
+    assert!(
+        response.status().is_success(),
+        "status={}",
+        response.status()
+    );
+
+    let body: serde_json::Value = test::read_body_json(response).await;
+    let events = body.as_array().expect("response should be an array");
+    assert_eq!(events.len(), 1, "filtered path should not be queued");
+
+    let path = events[0]["file_path"]
+        .as_str()
+        .expect("file_path in response");
+    assert_eq!(path, "/media/tv/Westworld/Season 1/Westworld.S01E01.mkv");
 }
 
 fn test_auth_header() -> String {

--- a/crates/service/src/lib.rs
+++ b/crates/service/src/lib.rs
@@ -8,5 +8,6 @@ pub mod settings;
 
 #[cfg(test)]
 mod tests {
+    mod targets;
     mod triggers;
 }

--- a/crates/service/src/runner.rs
+++ b/crates/service/src/runner.rs
@@ -260,7 +260,12 @@ impl<'a> PulseRunner<'a> {
                         .get(&x.event_source)
                         .is_none_or(|trigger| !trigger.excludes().contains(name))
                 })
+                .filter(|x| target.should_process_event(x))
                 .collect::<Vec<&mut ScanEvent>>();
+
+            if evs.is_empty() {
+                continue;
+            }
 
             let res = target
                 .process(

--- a/crates/service/src/settings/mod.rs
+++ b/crates/service/src/settings/mod.rs
@@ -47,6 +47,9 @@ pub mod auth;
 /// ```
 pub mod opts;
 
+/// Path-level include/exclude filters for triggers and targets.
+pub mod path_filter;
+
 /// Rewrite structure for triggers
 ///
 /// Example:
@@ -98,6 +101,7 @@ pub fn default_triggers() -> HashMap<String, Trigger> {
             rewrite: None,
             timer: None,
             excludes: vec![],
+            filter: Default::default(),
         }),
     );
 
@@ -202,6 +206,7 @@ impl Settings {
                     rewrite: None,
                     timer: None,
                     excludes: vec![],
+                    filter: Default::default(),
                 }),
             );
         }

--- a/crates/service/src/settings/path_filter.rs
+++ b/crates/service/src/settings/path_filter.rs
@@ -1,0 +1,149 @@
+use autopulse_utils::regex::Regex;
+use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
+
+#[derive(Clone, Default, Serialize, Deserialize)]
+pub struct PathFilter {
+    /// Path regex patterns to include. Empty includes all paths unless excluded.
+    #[serde(default)]
+    pub include: IncludePaths,
+    /// Path regex patterns to exclude. Excludes win over includes.
+    #[serde(default)]
+    pub exclude: ExcludePaths,
+}
+
+impl PathFilter {
+    pub fn allows(&self, path: &str) -> bool {
+        (self.include.is_empty() || self.include.matches(path)) && !self.exclude.matches(path)
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct IncludePaths {
+    patterns: Vec<Regex>,
+    sources: Vec<String>,
+}
+
+impl IncludePaths {
+    pub fn is_empty(&self) -> bool {
+        self.patterns.is_empty()
+    }
+
+    pub fn matches(&self, path: &str) -> bool {
+        self.patterns.iter().any(|r| r.is_match(path))
+    }
+}
+
+impl<'de> Deserialize<'de> for IncludePaths {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let sources: Vec<String> = Vec::<String>::deserialize(d)?;
+        let mut patterns = Vec::with_capacity(sources.len());
+        for s in &sources {
+            let r = Regex::new(s).map_err(|e| {
+                D::Error::custom(format!("invalid filter.include regex `{s}`: {e}"))
+            })?;
+            patterns.push(r);
+        }
+        Ok(Self { patterns, sources })
+    }
+}
+
+impl Serialize for IncludePaths {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        self.sources.serialize(s)
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct ExcludePaths {
+    patterns: Vec<Regex>,
+    sources: Vec<String>,
+}
+
+impl ExcludePaths {
+    pub fn matches(&self, path: &str) -> bool {
+        self.patterns.iter().any(|r| r.is_match(path))
+    }
+}
+
+impl<'de> Deserialize<'de> for ExcludePaths {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let sources: Vec<String> = Vec::<String>::deserialize(d)?;
+        let mut patterns = Vec::with_capacity(sources.len());
+        for s in &sources {
+            let r = Regex::new(s).map_err(|e| {
+                D::Error::custom(format!("invalid filter.exclude regex `{s}`: {e}"))
+            })?;
+            patterns.push(r);
+        }
+        Ok(Self { patterns, sources })
+    }
+}
+
+impl Serialize for ExcludePaths {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        self.sources.serialize(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn includes_match_any_pattern() {
+        let filter: PathFilter = serde_json::from_value(serde_json::json!({
+            "include": ["^/books/", "^/podcasts/"]
+        }))
+        .unwrap();
+
+        assert!(filter.allows("/books/Novel.m4b"));
+        assert!(filter.allows("/podcasts/Episode.mp3"));
+        assert!(!filter.allows("/movies/Movie.mkv"));
+    }
+
+    #[test]
+    fn excludes_match_any_pattern() {
+        let filter: PathFilter = serde_json::from_value(serde_json::json!({
+            "exclude": ["/samples/", "\\.tmp$"]
+        }))
+        .unwrap();
+
+        assert!(!filter.allows("/books/samples/Sample.m4b"));
+        assert!(!filter.allows("/books/file.tmp"));
+        assert!(filter.allows("/books/Novel.m4b"));
+    }
+
+    #[test]
+    fn exclude_wins_over_include() {
+        let filter: PathFilter = serde_json::from_value(serde_json::json!({
+            "include": ["^/books/"],
+            "exclude": ["^/books/samples/"]
+        }))
+        .unwrap();
+
+        assert!(filter.allows("/books/Novel.m4b"));
+        assert!(!filter.allows("/books/samples/Sample.m4b"));
+    }
+
+    #[test]
+    fn invalid_include_regex_rejected_at_config_load() {
+        let res: Result<PathFilter, _> = serde_json::from_value(serde_json::json!({
+            "include": ["[unclosed"]
+        }));
+
+        assert!(res.is_err());
+        let msg = format!("{}", res.err().unwrap());
+        assert!(msg.contains("invalid filter.include regex"));
+    }
+
+    #[test]
+    fn invalid_exclude_regex_rejected_at_config_load() {
+        let res: Result<PathFilter, _> = serde_json::from_value(serde_json::json!({
+            "exclude": ["[unclosed"]
+        }));
+
+        assert!(res.is_err());
+        let msg = format!("{}", res.err().unwrap());
+        assert!(msg.contains("invalid filter.exclude regex"));
+    }
+}

--- a/crates/service/src/settings/targets/audiobookshelf.rs
+++ b/crates/service/src/settings/targets/audiobookshelf.rs
@@ -1,4 +1,5 @@
 use super::{Request, RequestBuilderPerform};
+use crate::settings::path_filter::PathFilter;
 use crate::settings::rewrite::Rewrite;
 use crate::settings::targets::TargetProcess;
 use autopulse_database::models::ScanEvent;
@@ -17,6 +18,9 @@ pub struct Audiobookshelf {
     pub token: String,
     /// Rewrite path for the file
     pub rewrite: Option<Rewrite>,
+    /// Path filter matched against the target-rewritten path.
+    #[serde(default)]
+    pub filter: PathFilter,
     /// HTTP request options
     #[serde(default)]
     pub request: Request,

--- a/crates/service/src/settings/targets/autopulse.rs
+++ b/crates/service/src/settings/targets/autopulse.rs
@@ -1,4 +1,5 @@
 use super::{Request, RequestBuilderPerform};
+use crate::settings::path_filter::PathFilter;
 use crate::settings::rewrite::Rewrite;
 use crate::settings::{auth::Auth, targets::TargetProcess};
 use autopulse_database::models::ScanEvent;
@@ -17,6 +18,9 @@ pub struct Autopulse {
     pub trigger: Option<String>,
     /// Rewrite path for the file
     pub rewrite: Option<Rewrite>,
+    /// Path filter matched against the target-rewritten path.
+    #[serde(default)]
+    pub filter: PathFilter,
     /// HTTP request options
     #[serde(default)]
     pub request: Request,

--- a/crates/service/src/settings/targets/command.rs
+++ b/crates/service/src/settings/targets/command.rs
@@ -1,3 +1,4 @@
+use crate::settings::path_filter::PathFilter;
 use crate::settings::rewrite::Rewrite;
 use crate::settings::targets::TargetProcess;
 use autopulse_database::models::ScanEvent;
@@ -23,6 +24,9 @@ pub struct Command {
     pub raw: Option<String>,
     /// Rewrite path for the file
     pub rewrite: Option<Rewrite>,
+    /// Path filter matched against the target-rewritten path.
+    #[serde(default)]
+    pub filter: PathFilter,
 }
 
 impl Command {

--- a/crates/service/src/settings/targets/emby.rs
+++ b/crates/service/src/settings/targets/emby.rs
@@ -1,4 +1,5 @@
 use super::{Request, RequestBuilderPerform};
+use crate::settings::path_filter::PathFilter;
 use crate::settings::rewrite::Rewrite;
 use crate::settings::targets::TargetProcess;
 use anyhow::Context;
@@ -33,6 +34,9 @@ pub struct Emby {
     pub refresh_metadata: bool,
     /// Rewrite path for the file
     pub rewrite: Option<Rewrite>,
+    /// Path filter matched against the target-rewritten path.
+    #[serde(default)]
+    pub filter: PathFilter,
     /// HTTP request options
     #[serde(default)]
     pub request: Request,
@@ -482,6 +486,7 @@ mod tests {
             metadata_refresh_mode: EmbyMetadataRefreshMode::default(),
             refresh_metadata: true,
             rewrite: None,
+            filter: PathFilter::default(),
             request: Request::default(),
             path_match: PathMatch::default(),
         }

--- a/crates/service/src/settings/targets/fileflows.rs
+++ b/crates/service/src/settings/targets/fileflows.rs
@@ -1,4 +1,5 @@
 use super::{Request, RequestBuilderPerform};
+use crate::settings::path_filter::PathFilter;
 use crate::settings::rewrite::Rewrite;
 use crate::settings::targets::TargetProcess;
 use anyhow::Context;
@@ -16,6 +17,9 @@ pub struct FileFlows {
     pub url: String,
     /// Rewrite path for the file
     pub rewrite: Option<Rewrite>,
+    /// Path filter matched against the target-rewritten path.
+    #[serde(default)]
+    pub filter: PathFilter,
     /// HTTP request options
     #[serde(default)]
     pub request: Request,

--- a/crates/service/src/settings/targets/mod.rs
+++ b/crates/service/src/settings/targets/mod.rs
@@ -185,6 +185,7 @@ pub mod sonarr;
 /// See [`Tdarr`] for all options
 pub mod tdarr;
 
+use crate::settings::{path_filter::PathFilter, rewrite::Rewrite};
 use audiobookshelf::Audiobookshelf;
 use autopulse_database::models::ScanEvent;
 use reqwest::{header, RequestBuilder, Response};
@@ -288,6 +289,41 @@ pub enum Target {
     FileFlows(FileFlows),
     Autopulse(Autopulse),
     Audiobookshelf(Audiobookshelf),
+}
+
+impl Target {
+    fn rewrite(&self) -> &Option<Rewrite> {
+        match self {
+            Self::Plex(t) => &t.rewrite,
+            Self::Jellyfin(t) | Self::Emby(t) => &t.rewrite,
+            Self::Tdarr(t) => &t.rewrite,
+            Self::Sonarr(t) => &t.rewrite,
+            Self::Radarr(t) => &t.rewrite,
+            Self::Command(t) => &t.rewrite,
+            Self::FileFlows(t) => &t.rewrite,
+            Self::Autopulse(t) => &t.rewrite,
+            Self::Audiobookshelf(t) => &t.rewrite,
+        }
+    }
+
+    fn filter(&self) -> &PathFilter {
+        match self {
+            Self::Plex(t) => &t.filter,
+            Self::Jellyfin(t) | Self::Emby(t) => &t.filter,
+            Self::Tdarr(t) => &t.filter,
+            Self::Sonarr(t) => &t.filter,
+            Self::Radarr(t) => &t.filter,
+            Self::Command(t) => &t.filter,
+            Self::FileFlows(t) => &t.filter,
+            Self::Autopulse(t) => &t.filter,
+            Self::Audiobookshelf(t) => &t.filter,
+        }
+    }
+
+    pub fn should_process_event(&self, ev: &ScanEvent) -> bool {
+        let path = ev.get_path(self.rewrite());
+        self.filter().allows(&path)
+    }
 }
 
 pub trait TargetProcess {

--- a/crates/service/src/settings/targets/plex.rs
+++ b/crates/service/src/settings/targets/plex.rs
@@ -1,4 +1,5 @@
 use super::{Request, RequestBuilderPerform};
+use crate::settings::path_filter::PathFilter;
 use crate::settings::rewrite::Rewrite;
 use crate::settings::targets::TargetProcess;
 use anyhow::Context;
@@ -26,6 +27,9 @@ pub struct Plex {
     pub analyze: bool,
     /// Rewrite path for the file
     pub rewrite: Option<Rewrite>,
+    /// Path filter matched against the target-rewritten path.
+    #[serde(default)]
+    pub filter: PathFilter,
     /// HTTP request options
     #[serde(default)]
     pub request: Request,
@@ -530,6 +534,7 @@ mod tests {
             refresh: false,
             analyze: false,
             rewrite: None,
+            filter: PathFilter::default(),
             request: Request::default(),
         };
 
@@ -566,6 +571,7 @@ mod tests {
             refresh: false,
             analyze: false,
             rewrite: None,
+            filter: PathFilter::default(),
             request: Request::default(),
         };
 

--- a/crates/service/src/settings/targets/radarr.rs
+++ b/crates/service/src/settings/targets/radarr.rs
@@ -1,3 +1,4 @@
+use crate::settings::path_filter::PathFilter;
 use crate::settings::rewrite::Rewrite;
 use crate::settings::targets::TargetProcess;
 use autopulse_database::models::ScanEvent;
@@ -17,6 +18,9 @@ pub struct Radarr {
     pub token: String,
     /// Rewrite path for the file
     pub rewrite: Option<Rewrite>,
+    /// Path filter matched against the target-rewritten path.
+    #[serde(default)]
+    pub filter: PathFilter,
     /// HTTP request options
     #[serde(default)]
     pub request: Request,

--- a/crates/service/src/settings/targets/sonarr.rs
+++ b/crates/service/src/settings/targets/sonarr.rs
@@ -1,3 +1,4 @@
+use crate::settings::path_filter::PathFilter;
 use crate::settings::rewrite::Rewrite;
 use crate::settings::targets::TargetProcess;
 use autopulse_database::models::ScanEvent;
@@ -17,6 +18,9 @@ pub struct Sonarr {
     pub token: String,
     /// Rewrite path for the file
     pub rewrite: Option<Rewrite>,
+    /// Path filter matched against the target-rewritten path.
+    #[serde(default)]
+    pub filter: PathFilter,
     /// HTTP request options
     #[serde(default)]
     pub request: Request,

--- a/crates/service/src/settings/targets/tdarr.rs
+++ b/crates/service/src/settings/targets/tdarr.rs
@@ -1,3 +1,4 @@
+use crate::settings::path_filter::PathFilter;
 use crate::settings::rewrite::Rewrite;
 use crate::settings::targets::TargetProcess;
 use autopulse_database::models::ScanEvent;
@@ -14,6 +15,9 @@ pub struct Tdarr {
     pub db_id: String,
     /// Rewrite path for the file
     pub rewrite: Option<Rewrite>,
+    /// Path filter matched against the target-rewritten path.
+    #[serde(default)]
+    pub filter: PathFilter,
     /// HTTP request options
     #[serde(default)]
     pub request: Request,

--- a/crates/service/src/settings/triggers/autoscan.rs
+++ b/crates/service/src/settings/triggers/autoscan.rs
@@ -1,3 +1,4 @@
+use crate::settings::path_filter::PathFilter;
 use crate::settings::rewrite::Rewrite;
 use crate::settings::timer::Timer;
 use crate::settings::triggers::TriggerConfig;
@@ -12,6 +13,9 @@ pub struct Autoscan {
     /// Targets to ignore
     #[serde(default)]
     pub excludes: Vec<String>,
+    /// Path filter matched against the rewritten file path.
+    #[serde(default)]
+    pub filter: PathFilter,
 }
 
 impl TriggerConfig for Autoscan {
@@ -25,6 +29,10 @@ impl TriggerConfig for Autoscan {
 
     fn excludes(&self) -> &Vec<String> {
         &self.excludes
+    }
+
+    fn filter(&self) -> &PathFilter {
+        &self.filter
     }
 }
 

--- a/crates/service/src/settings/triggers/lidarr.rs
+++ b/crates/service/src/settings/triggers/lidarr.rs
@@ -1,3 +1,4 @@
+use crate::settings::path_filter::PathFilter;
 use crate::settings::rewrite::Rewrite;
 use crate::settings::timer::EventTimers;
 use crate::settings::{
@@ -15,6 +16,9 @@ pub struct Lidarr {
     /// Targets to ignore
     #[serde(default)]
     pub excludes: Vec<String>,
+    /// Path filter matched against the rewritten file path.
+    #[serde(default)]
+    pub filter: PathFilter,
     /// Event-specific timers
     pub event_timers: Option<EventTimers>,
 }
@@ -30,6 +34,10 @@ impl TriggerConfig for Lidarr {
 
     fn excludes(&self) -> &Vec<String> {
         &self.excludes
+    }
+
+    fn filter(&self) -> &PathFilter {
+        &self.filter
     }
 
     fn event_timers(&self) -> Option<&EventTimers> {

--- a/crates/service/src/settings/triggers/manual.rs
+++ b/crates/service/src/settings/triggers/manual.rs
@@ -1,3 +1,4 @@
+use crate::settings::path_filter::PathFilter;
 use crate::settings::rewrite::Rewrite;
 use crate::settings::timer::Timer;
 use crate::settings::triggers::TriggerConfig;
@@ -12,6 +13,9 @@ pub struct Manual {
     /// Targets to ignore
     #[serde(default)]
     pub excludes: Vec<String>,
+    /// Path filter matched against the rewritten file path.
+    #[serde(default)]
+    pub filter: PathFilter,
 }
 
 impl TriggerConfig for Manual {
@@ -25,6 +29,10 @@ impl TriggerConfig for Manual {
 
     fn excludes(&self) -> &Vec<String> {
         &self.excludes
+    }
+
+    fn filter(&self) -> &PathFilter {
+        &self.filter
     }
 }
 

--- a/crates/service/src/settings/triggers/mod.rs
+++ b/crates/service/src/settings/triggers/mod.rs
@@ -204,6 +204,7 @@ pub mod readarr;
 /// See [`Sonarr`] for all options
 pub mod sonarr;
 
+use crate::settings::path_filter::PathFilter;
 use crate::settings::timer::EventTimers;
 use crate::settings::timer::Timer;
 use crate::settings::{rewrite::Rewrite, triggers::autoscan::Autoscan};
@@ -230,6 +231,7 @@ pub trait TriggerConfig {
     fn rewrite(&self) -> Option<&Rewrite>;
     fn timer(&self) -> Option<&Timer>;
     fn excludes(&self) -> &Vec<String>;
+    fn filter(&self) -> &PathFilter;
     fn event_timers(&self) -> Option<&EventTimers> {
         None
     }
@@ -311,5 +313,9 @@ impl Trigger {
 
     pub fn excludes(&self) -> &Vec<String> {
         self.as_config().excludes()
+    }
+
+    pub fn should_process_path(&self, path: &str) -> bool {
+        self.as_config().filter().allows(path)
     }
 }

--- a/crates/service/src/settings/triggers/notify.rs
+++ b/crates/service/src/settings/triggers/notify.rs
@@ -1,3 +1,4 @@
+use crate::settings::path_filter::PathFilter;
 use crate::settings::rewrite::Rewrite;
 use crate::settings::timer::Timer;
 use crate::settings::triggers::TriggerConfig;
@@ -62,6 +63,9 @@ pub struct Notify {
     /// Targets to exclude
     #[serde(default)]
     pub excludes: Vec<String>,
+    /// Path filter matched against the rewritten file path.
+    #[serde(default)]
+    pub filter: PathFilter,
     /// Timer
     pub timer: Option<Timer>,
     /// Debounce timeout in seconds (default: 2)
@@ -79,6 +83,10 @@ impl TriggerConfig for Notify {
 
     fn excludes(&self) -> &Vec<String> {
         &self.excludes
+    }
+
+    fn filter(&self) -> &PathFilter {
+        &self.filter
     }
 }
 
@@ -112,6 +120,11 @@ impl Notify {
 
         if let Some(rewrite) = &self.rewrite {
             path = rewrite.rewrite_path(path);
+        }
+
+        if !self.filter.allows(&path) {
+            trace!("notify trigger filtered path '{path}'");
+            return Ok(());
         }
 
         tx.send((path, reason)).map_err(|e| anyhow::anyhow!(e))

--- a/crates/service/src/settings/triggers/radarr.rs
+++ b/crates/service/src/settings/triggers/radarr.rs
@@ -1,3 +1,4 @@
+use crate::settings::path_filter::PathFilter;
 use crate::settings::rewrite::Rewrite;
 use crate::settings::timer::{EventTimers, Timer};
 use crate::settings::triggers::{TriggerConfig, TriggerRequest};
@@ -13,6 +14,9 @@ pub struct Radarr {
     /// Targets to ignore
     #[serde(default)]
     pub excludes: Vec<String>,
+    /// Path filter matched against the rewritten file path.
+    #[serde(default)]
+    pub filter: PathFilter,
     /// Event-specific timers
     pub event_timers: Option<EventTimers>,
 }
@@ -28,6 +32,10 @@ impl TriggerConfig for Radarr {
 
     fn excludes(&self) -> &Vec<String> {
         &self.excludes
+    }
+
+    fn filter(&self) -> &PathFilter {
+        &self.filter
     }
 
     fn event_timers(&self) -> Option<&EventTimers> {

--- a/crates/service/src/settings/triggers/readarr.rs
+++ b/crates/service/src/settings/triggers/readarr.rs
@@ -1,3 +1,4 @@
+use crate::settings::path_filter::PathFilter;
 use crate::settings::rewrite::Rewrite;
 use crate::settings::timer::{EventTimers, Timer};
 use crate::settings::triggers::{TriggerConfig, TriggerRequest};
@@ -12,6 +13,9 @@ pub struct Readarr {
     /// Targets to ignore
     #[serde(default)]
     pub excludes: Vec<String>,
+    /// Path filter matched against the rewritten file path.
+    #[serde(default)]
+    pub filter: PathFilter,
     /// Event-specific timers
     pub event_timers: Option<EventTimers>,
 }
@@ -27,6 +31,10 @@ impl TriggerConfig for Readarr {
 
     fn excludes(&self) -> &Vec<String> {
         &self.excludes
+    }
+
+    fn filter(&self) -> &PathFilter {
+        &self.filter
     }
 
     fn event_timers(&self) -> Option<&EventTimers> {

--- a/crates/service/src/settings/triggers/sonarr.rs
+++ b/crates/service/src/settings/triggers/sonarr.rs
@@ -1,3 +1,4 @@
+use crate::settings::path_filter::PathFilter;
 use crate::settings::rewrite::Rewrite;
 use crate::settings::timer::{EventTimers, Timer};
 use crate::settings::triggers::{TriggerConfig, TriggerRequest};
@@ -13,6 +14,9 @@ pub struct Sonarr {
     /// Targets to ignore
     #[serde(default)]
     pub excludes: Vec<String>,
+    /// Path filter matched against the rewritten file path.
+    #[serde(default)]
+    pub filter: PathFilter,
     /// Event-specific timers
     pub event_timers: Option<EventTimers>,
 }
@@ -28,6 +32,10 @@ impl TriggerConfig for Sonarr {
 
     fn excludes(&self) -> &Vec<String> {
         &self.excludes
+    }
+
+    fn filter(&self) -> &PathFilter {
+        &self.filter
     }
 
     fn event_timers(&self) -> Option<&EventTimers> {

--- a/crates/service/src/tests/targets/mod.rs
+++ b/crates/service/src/tests/targets/mod.rs
@@ -1,0 +1,1 @@
+pub mod path_filter;

--- a/crates/service/src/tests/targets/path_filter.rs
+++ b/crates/service/src/tests/targets/path_filter.rs
@@ -1,0 +1,125 @@
+use crate::settings::targets::Target;
+use autopulse_database::models::{FoundStatus, ProcessStatus, ScanEvent};
+
+fn event(path: &str) -> ScanEvent {
+    let now = chrono::Utc::now().naive_utc();
+
+    ScanEvent {
+        id: "event-id".to_string(),
+        event_source: "trigger".to_string(),
+        event_timestamp: now,
+        file_path: path.to_string(),
+        file_hash: None,
+        process_status: ProcessStatus::Pending.into(),
+        found_status: FoundStatus::Found.into(),
+        failed_times: 0,
+        next_retry_at: None,
+        targets_hit: String::new(),
+        found_at: Some(now),
+        processed_at: None,
+        created_at: now,
+        updated_at: now,
+        can_process: now,
+    }
+}
+
+#[test]
+fn target_filter_include_matches_rewritten_path() {
+    let target: Target = serde_json::from_value(serde_json::json!({
+        "type": "audiobookshelf",
+        "url": "http://audiobookshelf:13378",
+        "token": "token",
+        "rewrite": { "from": "/downloads/audiobooks", "to": "/books" },
+        "filter": { "include": ["^/books/"] }
+    }))
+    .unwrap();
+
+    assert!(target.should_process_event(&event("/downloads/audiobooks/Book/Chapter 1.m4b")));
+}
+
+#[test]
+fn target_filter_include_rejects_non_matching_path() {
+    let target: Target = serde_json::from_value(serde_json::json!({
+        "type": "audiobookshelf",
+        "url": "http://audiobookshelf:13378",
+        "token": "token",
+        "filter": { "include": ["^/books/"] }
+    }))
+    .unwrap();
+
+    assert!(!target.should_process_event(&event("/movies/Movie.mkv")));
+}
+
+#[test]
+fn target_filter_exclude_rejects_matching_path() {
+    let target: Target = serde_json::from_value(serde_json::json!({
+        "type": "audiobookshelf",
+        "url": "http://audiobookshelf:13378",
+        "token": "token",
+        "filter": { "exclude": ["/podcasts/"] }
+    }))
+    .unwrap();
+
+    assert!(!target.should_process_event(&event("/books/podcasts/Episode 1.mp3")));
+}
+
+#[test]
+fn target_filter_exclude_wins_over_include() {
+    let target: Target = serde_json::from_value(serde_json::json!({
+        "type": "audiobookshelf",
+        "url": "http://audiobookshelf:13378",
+        "token": "token",
+        "filter": {
+            "include": ["^/books/"],
+            "exclude": ["^/books/podcasts/"]
+        }
+    }))
+    .unwrap();
+
+    assert!(!target.should_process_event(&event("/books/podcasts/Episode 1.mp3")));
+}
+
+#[test]
+fn target_filter_include_and_exclude_deserialize() {
+    let target: Target = serde_json::from_value(serde_json::json!({
+        "type": "audiobookshelf",
+        "url": "http://audiobookshelf:13378",
+        "token": "token",
+        "filter": {
+            "include": ["^/books/"],
+            "exclude": ["/samples/"]
+        }
+    }))
+    .unwrap();
+
+    assert!(target.should_process_event(&event("/books/Novel.m4b")));
+    assert!(!target.should_process_event(&event("/books/samples/Sample.m4b")));
+}
+
+#[test]
+fn invalid_target_include_regex_is_rejected() {
+    let res: Result<Target, _> = serde_json::from_value(serde_json::json!({
+        "type": "audiobookshelf",
+        "url": "http://audiobookshelf:13378",
+        "token": "token",
+        "filter": { "include": ["[unclosed"] }
+    }));
+
+    assert!(res.is_err());
+    let msg = res.err().unwrap().to_string();
+    assert!(msg.contains("invalid filter.include regex"));
+}
+
+#[test]
+fn invalid_target_exclude_regex_is_rejected() {
+    let res: Result<Target, _> = serde_json::from_value(serde_json::json!({
+        "type": "audiobookshelf",
+        "url": "http://audiobookshelf:13378",
+        "token": "token",
+        "filter": { "exclude": ["[unclosed"] }
+    }));
+
+    assert!(res.is_err());
+    let msg = res.err().unwrap().to_string();
+    assert!(msg.contains("invalid filter.exclude regex"));
+}

--- a/crates/service/src/tests/triggers/mod.rs
+++ b/crates/service/src/tests/triggers/mod.rs
@@ -1,5 +1,6 @@
 pub mod lidarr;
 pub mod notify;
+pub mod path_filter;
 pub mod radarr;
 pub mod readarr;
 pub mod sonarr;

--- a/crates/service/src/tests/triggers/notify.rs
+++ b/crates/service/src/tests/triggers/notify.rs
@@ -16,6 +16,7 @@ mod tests {
             rewrite: None,
             recursive: None,
             excludes: vec![],
+            filter: Default::default(),
             filters: None,
             timer: Default::default(),
             backend: Default::default(),

--- a/crates/service/src/tests/triggers/path_filter.rs
+++ b/crates/service/src/tests/triggers/path_filter.rs
@@ -1,0 +1,14 @@
+use crate::settings::triggers::Trigger;
+
+#[test]
+fn sonarr_trigger_excludes_path_via_regex() {
+    let trigger: Trigger = serde_json::from_value(serde_json::json!({
+        "type": "sonarr",
+        "filter": { "exclude": ["/tv/Excluded Show/", "\\.sample\\.mkv$"] }
+    }))
+    .unwrap();
+
+    assert!(!trigger.should_process_path("/tv/Excluded Show/S01E01.mkv"));
+    assert!(!trigger.should_process_path("/tv/Other/S01E02.sample.mkv"));
+    assert!(trigger.should_process_path("/tv/Other/S01E02.mkv"));
+}


### PR DESCRIPTION
# Description

Adds a shared `filter.include`/`filter.exclude` path filter to triggers and targets, dropping trigger events before queueing and routing target dispatch after target rewrites without retrying incompatible targets.

Resolves #368

## Type of change

- [ ] Bug (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (addition or change to documentation)