### PR TITLE
feat(settings): add config load diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,20 +369,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "arraydeque"
-version = "0.5.1"
+name = "atomic"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
-
-[[package]]
-name = "async-trait"
-version = "0.1.89"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "bytemuck",
 ]
 
 [[package]]
@@ -465,7 +457,7 @@ dependencies = [
  "autopulse-utils",
  "base64 0.22.1",
  "chrono",
- "config",
+ "figment",
  "futures",
  "html-escape",
  "notify-debouncer-full",
@@ -473,6 +465,7 @@ dependencies = [
  "serde",
  "serde_json",
  "struson",
+ "tempfile",
  "tokio",
  "tracing",
 ]
@@ -546,9 +539,6 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
-dependencies = [
- "serde_core",
-]
 
 [[package]]
 name = "block-buffer"
@@ -594,6 +584,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
@@ -728,59 +724,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "config"
-version = "0.15.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f316c6237b2d38be61949ecd15268a4c6ca32570079394a2444d9ce2c72a72d8"
-dependencies = [
- "async-trait",
- "convert_case 0.6.0",
- "json5",
- "pathdiff",
- "ron",
- "rust-ini",
- "serde-untagged",
- "serde_core",
- "serde_json",
- "toml 1.1.2+spec-1.1.0",
- "winnow 1.0.0",
- "yaml-rust2",
-]
-
-[[package]]
 name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
-
-[[package]]
-name = "const-random"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
-dependencies = [
- "const-random-macro",
-]
-
-[[package]]
-name = "const-random-macro"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
-dependencies = [
- "getrandom 0.2.17",
- "once_cell",
- "tiny-keccak",
-]
-
-[[package]]
-name = "convert_case"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "convert_case"
@@ -876,12 +823,6 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -992,7 +933,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "convert_case 0.10.0",
+ "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -1086,15 +1027,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dlv-list"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
-dependencies = [
- "const-random",
-]
-
-[[package]]
 name = "downcast-rs"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1153,17 +1085,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "erased-serde"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e8918065695684b2b0702da20382d5ae6065cf3327bc2d6436bd49a71ce9f3"
-dependencies = [
- "serde",
- "serde_core",
- "typeid",
-]
-
-[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1178,6 +1099,22 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "figment"
+version = "0.10.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
+dependencies = [
+ "atomic",
+ "pear",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "toml 0.8.23",
+ "uncased",
+ "version_check",
+]
 
 [[package]]
 name = "file-id"
@@ -1449,12 +1386,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-
-[[package]]
-name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1469,15 +1400,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "foldhash 0.2.0",
-]
-
-[[package]]
-name = "hashlink"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
-dependencies = [
- "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1845,6 +1767,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "inlinable_string"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
 name = "inotify"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1944,17 +1872,6 @@ checksum = "93f0862381daaec758576dcc22eb7bbf4d7efd67328553f3b45a412a51a3fb21"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "json5"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
-dependencies = [
- "pest",
- "pest_derive",
- "serde",
 ]
 
 [[package]]
@@ -2307,16 +2224,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordered-multimap"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
-dependencies = [
- "dlv-list",
- "hashbrown 0.14.5",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2340,59 +2247,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "pathdiff"
-version = "0.2.3"
+name = "pear"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+checksum = "bdeeaa00ce488657faba8ebf44ab9361f9365a97bd39ffb8a60663f57ff4b467"
+dependencies = [
+ "inlinable_string",
+ "pear_codegen",
+ "yansi",
+]
+
+[[package]]
+name = "pear_codegen"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bab5b985dc082b345f812b7df84e1bef27e7207b39e448439ba8bd69c93f147"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "pest"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
-dependencies = [
- "memchr",
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
-dependencies = [
- "pest",
- "sha2 0.10.9",
-]
 
 [[package]]
 name = "pin-project-lite"
@@ -2499,6 +2380,7 @@ dependencies = [
  "quote",
  "syn",
  "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -2753,20 +2635,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ron"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd490c5b18261893f14449cbd28cb9c0b637aebf161cd77900bfdedaff21ec32"
-dependencies = [
- "bitflags 2.11.0",
- "once_cell",
- "serde",
- "serde_derive",
- "typeid",
- "unicode-ident",
-]
-
-[[package]]
 name = "rsqlite-vfs"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2808,16 +2676,6 @@ checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
 dependencies = [
  "sha2 0.10.9",
  "walkdir",
-]
-
-[[package]]
-name = "rust-ini"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
-dependencies = [
- "cfg-if",
- "ordered-multimap",
 ]
 
 [[package]]
@@ -3008,18 +2866,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-untagged"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9faf48a4a2d2693be24c6289dbe26552776eb7737074e6722891fadbe6c5058"
-dependencies = [
- "erased-serde",
- "serde",
- "serde_core",
- "typeid",
-]
-
-[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3078,6 +2924,15 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
@@ -3095,6 +2950,19 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -3310,7 +3178,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -3396,15 +3264,6 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
 ]
 
 [[package]]
@@ -3507,13 +3366,25 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml"
 version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned",
+ "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
@@ -3521,16 +3392,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "1.1.2+spec-1.1.0"
+name = "toml_datetime"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
- "serde_core",
- "serde_spanned",
- "toml_datetime 1.1.1+spec-1.1.0",
- "toml_parser",
- "winnow 1.0.0",
+ "serde",
 ]
 
 [[package]]
@@ -3543,12 +3410,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "1.1.1+spec-1.1.0"
+name = "toml_edit"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "serde_core",
+ "indexmap",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -3559,6 +3431,12 @@ checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow 1.0.0",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -3693,22 +3571,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "typeid"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
-
-[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
-name = "ucd-trie"
-version = "0.1.7"
+name = "uncased"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -3737,6 +3612,12 @@ dependencies = [
  "crypto-common 0.1.7",
  "subtle",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -4281,15 +4162,15 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "wit-bindgen"
@@ -4386,15 +4267,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
-name = "yaml-rust2"
-version = "0.11.0"
+name = "yansi"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "631a50d867fafb7093e709d75aaee9e0e0d5deb934021fcea25ac2fe09edc51e"
-dependencies = [
- "arraydeque",
- "encoding_rs",
- "hashlink",
-]
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ For example: `AUTOPULSE__APP__DATABASE_URL`
 
 An example has been provided in the [example](https://github.com/dan-online/autopulse/blob/main/example) directory
 
-> Note: You can provide the config with `json`, `toml`, `yaml`, `json5`, `ron`, or `ini` format
+> Note: You can provide the config as `config.toml`, `config.yaml`, `config.yml`, or `config.json`
 
 > Note: You can also provide the path to a variable by appending `__FILE`
 > For example: `AUTOPULSE__AUTH__PASSWORD__FILE=/run/secrets/autopulse_password`

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Here's some quick links:
 
 #### Configuration
 
-autopulse requires a configuration file to run. By default, it looks for `config.toml` in the current working directory. You can override the default values using a config file or by [setting environment variables](https://github.com/dan-online/autopulse/blob/main/example/docker-compose.yml) in the format of: ``AUTOPULSE__{SECTION}__{KEY}``. 
+autopulse requires a configuration file to run. By default, it searches the current working directory for `config.toml`, `config.yaml`, `config.yml`, or `config.json` in that order. You can pass `--config /path/to/config.toml` to load an explicit file, and override values by [setting environment variables](https://github.com/dan-online/autopulse/blob/main/example/docker-compose.yml) in the format of: ``AUTOPULSE__{SECTION}__{KEY}``.
 
 For example: `AUTOPULSE__APP__DATABASE_URL`
 

--- a/crates/service/Cargo.toml
+++ b/crates/service/Cargo.toml
@@ -28,7 +28,7 @@ reqwest = { version = "0.13.0", features = ["json", "stream"] }
 base64 = "0.22.1"
 
 # Config
-config = "0.15.6"
+figment = { version = "0.10", features = ["toml", "yaml", "json", "env"] }
 
 # File system notifications
 notify-debouncer-full = "0.7.0"
@@ -41,3 +41,6 @@ struson = { version = "0.7.0", features = [
     "simple-api",
     "serde",
 ] } # Parse Jellyfin response as a stream
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/service/src/settings/mod.rs
+++ b/crates/service/src/settings/mod.rs
@@ -1,7 +1,8 @@
+use anyhow::Context;
 use app::App;
 use auth::Auth;
 use figment::{
-    providers::{Env, Format, Json, Toml, Yaml},
+    providers::{Env, Format, Json, Serialized, Toml, Yaml},
     Figment,
 };
 use opts::Opts;
@@ -146,6 +147,59 @@ pub struct Settings {
     pub anchors: Vec<PathBuf>,
 }
 
+pub struct LoadedSettings {
+    pub settings: Settings,
+    pub diagnostics: Vec<ConfigDiagnostic>,
+}
+
+impl LoadedSettings {
+    pub fn log_diagnostics(&self) {
+        for diagnostic in &self.diagnostics {
+            diagnostic.log();
+        }
+    }
+}
+
+pub enum ConfigDiagnostic {
+    LoadedFile(PathBuf),
+    LoadedFileEnv {
+        count: usize,
+    },
+    MissingConfig {
+        cwd: PathBuf,
+        searched: Vec<PathBuf>,
+    },
+}
+
+impl ConfigDiagnostic {
+    fn log(&self) {
+        match self {
+            Self::LoadedFile(path) => {
+                tracing::info!(target: "autopulse", "loaded config from {}", path.display());
+            }
+            Self::LoadedFileEnv { count } => {
+                tracing::info!(
+                    target: "autopulse",
+                    "loaded {count} config override(s) from AUTOPULSE__...__FILE"
+                );
+            }
+            Self::MissingConfig { cwd, searched } => {
+                tracing::warn!(
+                    target: "autopulse",
+                    "no config file found in {}. Searched: {:?}. \
+                     Using defaults + environment overrides only. \
+                     Pass --config /path/to/config.toml or place one of the candidate files in the cwd.",
+                    cwd.display(),
+                    searched
+                        .iter()
+                        .map(|p| p.display().to_string())
+                        .collect::<Vec<_>>(),
+                );
+            }
+        }
+    }
+}
+
 impl Default for Settings {
     fn default() -> Self {
         Self {
@@ -182,31 +236,35 @@ impl Settings {
             .collect()
     }
 
-    /// Expands `AUTOPULSE__KEY__FILE=/path` environment variables into
-    /// `AUTOPULSE__KEY=<file contents>` so figment's `Env` provider can
-    /// read secrets sourced from files (Docker/Kubernetes secret mounts).
-    ///
-    /// # Safety
-    ///
-    /// Mutates the process environment. Must be called from `get_settings`
-    /// at startup, before any worker thread reads env vars. The trade-off
-    /// vs. a custom Provider is paid here so the figment chain stays
-    /// idiomatic.
-    unsafe fn expand_file_env_vars() {
-        let pending: Vec<(String, String)> = env::vars()
-            .filter_map(|(k, v)| {
-                let base = k.strip_suffix("__FILE")?.to_string();
-                let contents = std::fs::read_to_string(&v).ok()?;
-                Some((base, contents.trim().to_string()))
+    fn file_env_overrides_from(
+        vars: impl IntoIterator<Item = (String, String)>,
+    ) -> anyhow::Result<Vec<(String, String)>> {
+        const PREFIX: &str = "AUTOPULSE__";
+        const SUFFIX: &str = "__FILE";
+
+        vars.into_iter()
+            .filter_map(|(key, path)| {
+                let key_path = key
+                    .strip_prefix(PREFIX)?
+                    .strip_suffix(SUFFIX)?
+                    .replace("__", ".")
+                    .to_ascii_lowercase();
+                Some((key, key_path, path))
             })
-            .collect();
-        for (k, v) in pending {
-            // SAFETY: caller guarantees single-threaded startup context.
-            unsafe { env::set_var(k, v) };
-        }
+            .map(|(key, key_path, path)| {
+                let contents = std::fs::read_to_string(&path)
+                    .with_context(|| format!("failed to read file referenced by {key}: {path}"))?;
+
+                Ok((key_path, contents.trim().to_string()))
+            })
+            .collect()
     }
 
-    pub fn get_settings(optional_config_file: Option<String>) -> anyhow::Result<Self> {
+    fn file_env_overrides() -> anyhow::Result<Vec<(String, String)>> {
+        Self::file_env_overrides_from(env::vars())
+    }
+
+    pub fn get_settings(optional_config_file: Option<String>) -> anyhow::Result<LoadedSettings> {
         let cwd = env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
 
         let explicit = optional_config_file.is_some();
@@ -225,9 +283,7 @@ impl Settings {
             }
         }
 
-        // SAFETY: runs once at process startup before tokio spawns workers.
-        unsafe { Self::expand_file_env_vars() };
-
+        let mut diagnostics = vec![];
         let mut fig = Figment::new();
         if let Some(p) = chosen.as_deref() {
             fig = match p.extension().and_then(|s| s.to_str()) {
@@ -240,39 +296,38 @@ impl Settings {
                     p.display()
                 ),
             };
+            diagnostics.push(ConfigDiagnostic::LoadedFile(p.to_path_buf()));
+        } else if !explicit {
+            diagnostics.push(ConfigDiagnostic::MissingConfig {
+                cwd: cwd.clone(),
+                searched: Self::searched_paths(&cwd),
+            });
         }
         // Env overrides file (last-write-wins).
-        fig = fig.merge(Env::prefixed("AUTOPULSE__").split("__"));
+        fig = fig.merge(
+            Env::prefixed("AUTOPULSE__")
+                .filter(|key| !key.as_str().ends_with("__FILE"))
+                .split("__"),
+        );
+        // File-secret env vars override direct env vars, matching the old
+        // config source behavior without mutating the process environment.
+        let file_overrides = Self::file_env_overrides()?;
+        if !file_overrides.is_empty() {
+            diagnostics.push(ConfigDiagnostic::LoadedFileEnv {
+                count: file_overrides.len(),
+            });
+        }
+        for (key, value) in file_overrides {
+            fig = fig.merge(Serialized::default(&key, value));
+        }
 
         let mut settings: Self = fig.extract().map_err(|e| anyhow::anyhow!(e))?;
         settings.add_default_manual_trigger()?;
 
-        // Use figment's own provenance: ask each merged provider where
-        // its data came from. Avoids tracking "loaded_from" ourselves.
-        let mut saw_file = false;
-        for md in fig.metadata() {
-            if let Some(src) = md.source.as_ref() {
-                tracing::info!(target: "autopulse", "loaded config from {} ({})", src, md.name);
-                saw_file = true;
-            } else {
-                tracing::debug!(target: "autopulse", "config provider: {}", md.name);
-            }
-        }
-        if !saw_file && !explicit {
-            tracing::warn!(
-                target: "autopulse",
-                "no config file found in {}. Searched: {:?}. \
-                 Using defaults + environment overrides only. \
-                 Pass --config /path/to/config.toml or place one of the candidate files in the cwd.",
-                cwd.display(),
-                Self::searched_paths(&cwd)
-                    .iter()
-                    .map(|p| p.display().to_string())
-                    .collect::<Vec<_>>(),
-            );
-        }
-
-        Ok(settings)
+        Ok(LoadedSettings {
+            settings,
+            diagnostics,
+        })
     }
 
     /// Emits an INFO-level summary of the effective config shape at startup.
@@ -335,6 +390,65 @@ mod tests {
                 .file_name()
                 .unwrap(),
             "config.toml"
+        );
+    }
+
+    #[test]
+    fn file_env_overrides_read_autopulse_secret_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let secret = dir.path().join("password");
+        std::fs::write(&secret, "secret\n").unwrap();
+
+        let vars = vec![
+            (
+                "AUTOPULSE__AUTH__PASSWORD__FILE".to_string(),
+                secret.display().to_string(),
+            ),
+            ("OTHER__PASSWORD__FILE".to_string(), "ignored".to_string()),
+        ];
+
+        let overrides = Settings::file_env_overrides_from(vars).unwrap();
+
+        assert_eq!(
+            overrides,
+            vec![("auth.password".to_string(), "secret".to_string())]
+        );
+    }
+
+    #[test]
+    fn file_env_overrides_key_paths_deserialize_into_settings() {
+        let dir = tempfile::tempdir().unwrap();
+        let secret = dir.path().join("password");
+        std::fs::write(&secret, "secret\n").unwrap();
+
+        let overrides = Settings::file_env_overrides_from(vec![(
+            "AUTOPULSE__AUTH__PASSWORD__FILE".to_string(),
+            secret.display().to_string(),
+        )])
+        .unwrap();
+        let mut fig = Figment::new();
+        for (key, value) in overrides {
+            fig = fig.merge(Serialized::default(&key, value));
+        }
+
+        let settings = fig.extract::<Settings>().unwrap();
+
+        assert_eq!(settings.auth.password, "secret");
+    }
+
+    #[test]
+    fn file_env_overrides_error_when_secret_file_cannot_be_read() {
+        let vars = vec![(
+            "AUTOPULSE__AUTH__PASSWORD__FILE".to_string(),
+            "/tmp/missing-autopulse-secret".to_string(),
+        )];
+
+        let err = Settings::file_env_overrides_from(vars).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("failed to read file referenced by AUTOPULSE__AUTH__PASSWORD__FILE"),
+            "{err:?}"
         );
     }
 }

--- a/crates/service/src/settings/mod.rs
+++ b/crates/service/src/settings/mod.rs
@@ -1,9 +1,13 @@
 use app::App;
 use auth::Auth;
-use config::Config;
+use figment::{
+    providers::{Env, Format, Json, Toml, Yaml},
+    Figment,
+};
 use opts::Opts;
 use serde::{Deserialize, Serialize};
 use std::env;
+use std::path::Path;
 use std::{collections::HashMap, path::PathBuf};
 use targets::Target;
 use triggers::manual::Manual;
@@ -157,45 +161,131 @@ impl Default for Settings {
 }
 
 impl Settings {
-    fn resolve_env() -> HashMap<String, String> {
-        let mut out = HashMap::new();
+    /// Candidate filenames probed when no explicit `--config` is given.
+    /// Order is significant — the first match wins. The set is what
+    /// figment's bundled providers handle natively; json5/ron/ini are
+    /// not supported (dropped from the prior `config` crate setup).
+    pub const CONFIG_CANDIDATES: &'static [&'static str] =
+        &["config.toml", "config.yaml", "config.yml", "config.json"];
 
-        for (key, value) in env::vars() {
-            if let Some(base) = key.strip_suffix("__FILE") {
-                if let Ok(file_value) = std::fs::read_to_string(&value) {
-                    out.insert(base.to_string(), file_value.trim().to_string());
-                    continue;
-                }
-            }
+    pub fn resolved_config_path(cwd: &Path) -> Option<PathBuf> {
+        Self::CONFIG_CANDIDATES
+            .iter()
+            .map(|name| cwd.join(name))
+            .find(|p| p.is_file())
+    }
 
-            out.entry(key).or_insert(value);
+    pub fn searched_paths(cwd: &Path) -> Vec<PathBuf> {
+        Self::CONFIG_CANDIDATES
+            .iter()
+            .map(|n| cwd.join(n))
+            .collect()
+    }
+
+    /// Expands `AUTOPULSE__KEY__FILE=/path` environment variables into
+    /// `AUTOPULSE__KEY=<file contents>` so figment's `Env` provider can
+    /// read secrets sourced from files (Docker/Kubernetes secret mounts).
+    ///
+    /// # Safety
+    ///
+    /// Mutates the process environment. Must be called from `get_settings`
+    /// at startup, before any worker thread reads env vars. The trade-off
+    /// vs. a custom Provider is paid here so the figment chain stays
+    /// idiomatic.
+    unsafe fn expand_file_env_vars() {
+        let pending: Vec<(String, String)> = env::vars()
+            .filter_map(|(k, v)| {
+                let base = k.strip_suffix("__FILE")?.to_string();
+                let contents = std::fs::read_to_string(&v).ok()?;
+                Some((base, contents.trim().to_string()))
+            })
+            .collect();
+        for (k, v) in pending {
+            // SAFETY: caller guarantees single-threaded startup context.
+            unsafe { env::set_var(k, v) };
         }
-
-        out
     }
 
     pub fn get_settings(optional_config_file: Option<String>) -> anyhow::Result<Self> {
-        let mut settings = Config::builder()
-            .add_source(config::File::with_name("config").required(false))
-            .add_source(
-                config::Environment::with_prefix("AUTOPULSE")
-                    .separator("__")
-                    .source(Some(Self::resolve_env())),
-            );
+        let cwd = env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
 
-        if let Some(file_loc) = optional_config_file {
-            settings = settings.add_source(config::File::with_name(&file_loc));
+        let explicit = optional_config_file.is_some();
+        let chosen = optional_config_file
+            .map(PathBuf::from)
+            .or_else(|| Self::resolved_config_path(&cwd));
+
+        // Explicit --config path must exist. Silent fall-through to defaults
+        // when the user told us exactly where the file is would be the same
+        // bug class as #435.
+        if explicit {
+            if let Some(p) = &chosen {
+                if !p.is_file() {
+                    anyhow::bail!("--config {} does not exist", p.display());
+                }
+            }
         }
 
-        let settings = settings.build()?;
+        // SAFETY: runs once at process startup before tokio spawns workers.
+        unsafe { Self::expand_file_env_vars() };
 
-        let mut settings = settings
-            .try_deserialize::<Self>()
-            .map_err(|e| anyhow::anyhow!(e))?;
+        let mut fig = Figment::new();
+        if let Some(p) = chosen.as_deref() {
+            fig = match p.extension().and_then(|s| s.to_str()) {
+                Some("toml") => fig.merge(Toml::file(p)),
+                Some("yaml") | Some("yml") => fig.merge(Yaml::file(p)),
+                Some("json") => fig.merge(Json::file(p)),
+                other => anyhow::bail!(
+                    "unsupported config format {:?} for {} (supported: toml, yaml, yml, json)",
+                    other.unwrap_or(""),
+                    p.display()
+                ),
+            };
+        }
+        // Env overrides file (last-write-wins).
+        fig = fig.merge(Env::prefixed("AUTOPULSE__").split("__"));
 
+        let mut settings: Self = fig.extract().map_err(|e| anyhow::anyhow!(e))?;
         settings.add_default_manual_trigger()?;
 
+        // Use figment's own provenance: ask each merged provider where
+        // its data came from. Avoids tracking "loaded_from" ourselves.
+        let mut saw_file = false;
+        for md in fig.metadata() {
+            if let Some(src) = md.source.as_ref() {
+                tracing::info!(target: "autopulse", "loaded config from {} ({})", src, md.name);
+                saw_file = true;
+            } else {
+                tracing::debug!(target: "autopulse", "config provider: {}", md.name);
+            }
+        }
+        if !saw_file && !explicit {
+            tracing::warn!(
+                target: "autopulse",
+                "no config file found in {}. Searched: {:?}. \
+                 Using defaults + environment overrides only. \
+                 Pass --config /path/to/config.toml or place one of the candidate files in the cwd.",
+                cwd.display(),
+                Self::searched_paths(&cwd)
+                    .iter()
+                    .map(|p| p.display().to_string())
+                    .collect::<Vec<_>>(),
+            );
+        }
+
         Ok(settings)
+    }
+
+    /// Emits an INFO-level summary of the effective config shape at startup.
+    /// Just counts — keeps the line short and confirms the parse worked.
+    pub fn log_summary(&self) {
+        tracing::info!(
+            target: "autopulse",
+            "effective config: triggers={} targets={} webhooks={} anchors={}",
+            self.triggers.len(),
+            self.targets.len(),
+            self.webhooks.len(),
+            self.anchors.len(),
+        );
     }
 
     pub fn add_default_manual_trigger(&mut self) -> anyhow::Result<()> {
@@ -212,5 +302,39 @@ impl Settings {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn resolved_config_path_picks_toml_when_present() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("config.toml");
+        std::fs::File::create(&p).unwrap().write_all(b"").unwrap();
+        assert_eq!(Settings::resolved_config_path(dir.path()), Some(p));
+    }
+
+    #[test]
+    fn resolved_config_path_returns_none_when_empty_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(Settings::resolved_config_path(dir.path()).is_none());
+    }
+
+    #[test]
+    fn resolved_config_path_prefers_toml_over_yaml() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::File::create(dir.path().join("config.yaml")).unwrap();
+        std::fs::File::create(dir.path().join("config.toml")).unwrap();
+        assert_eq!(
+            Settings::resolved_config_path(dir.path())
+                .unwrap()
+                .file_name()
+                .unwrap(),
+            "config.toml"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -159,6 +159,7 @@ pub fn main() -> anyhow::Result<()> {
     match setup() {
         Ok((settings, guard)) => {
             info!("💫 autopulse v{} starting up...", env!("CARGO_PKG_VERSION"),);
+            settings.log_summary();
 
             if let Err(e) = run(settings, guard) {
                 error!("{:?}", e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,18 +128,20 @@ async fn run(settings: Settings, _guard: Option<WorkerGuard>) -> anyhow::Result<
 fn setup() -> anyhow::Result<(Settings, Option<WorkerGuard>)> {
     let args = Args::parse();
 
-    let settings = Settings::get_settings(args.config).context("failed to load settings");
+    let loaded = Settings::get_settings(args.config).context("failed to load settings");
 
-    match settings {
-        Ok(settings) => {
+    match loaded {
+        Ok(loaded) => {
+            let log_file_rollover = Rotation::from(&loaded.settings.opts.log_file_rollover);
             let guard = setup_logs(
-                &settings.app.log_level,
-                &settings.opts.log_file,
-                &(&settings.opts.log_file_rollover).into(),
-                settings.app.api_logging,
+                &loaded.settings.app.log_level,
+                &loaded.settings.opts.log_file,
+                &log_file_rollover,
+                loaded.settings.app.api_logging,
             )?;
+            loaded.log_diagnostics();
 
-            Ok((settings, guard))
+            Ok((loaded.settings, guard))
         }
         Err(e) => {
             setup_logs(


### PR DESCRIPTION
# Description

Logs loaded config sources, warns with searched paths when no config file is found, and fails missing explicit `--config` paths so Docker config mount mistakes are visible.

Resolves #435

**BREAKING:** Supported config files are now `config.toml`, `config.yaml`, `config.yml`, or `config.json`; `json5`, `ron`, and `ini` config files are no longer loaded.

## Type of change

- [ ] Bug (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (addition or change to documentation)