### PR TITLE
feat(service): dedupe pending scan events across triggers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,12 @@ version = "1.7.0"
 
 [features]
 vendored = ["autopulse-service/vendored", "postgres-vendored", "sqlite-vendored"]
-sqlite = ["autopulse-database/sqlite", "autopulse-server/sqlite"]
-postgres = ["autopulse-database/postgres", "autopulse-server/postgres"]
+sqlite = ["autopulse-database/sqlite", "autopulse-server/sqlite", "autopulse-service/sqlite"]
+postgres = [
+    "autopulse-database/postgres",
+    "autopulse-server/postgres",
+    "autopulse-service/postgres",
+]
 sqlite-vendored = ["sqlite", "autopulse-database/sqlite-vendored"]
 postgres-vendored = ["postgres", "autopulse-database/postgres-vendored"]
 default = ["sqlite", "postgres"]

--- a/crates/database/migrations/postgres/2026-05-30-000001_dedupe_pending_partial_index/down.sql
+++ b/crates/database/migrations/postgres/2026-05-30-000001_dedupe_pending_partial_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_scan_events_dedupe_pending_retry;

--- a/crates/database/migrations/postgres/2026-05-30-000001_dedupe_pending_partial_index/up.sql
+++ b/crates/database/migrations/postgres/2026-05-30-000001_dedupe_pending_partial_index/up.sql
@@ -1,0 +1,55 @@
+-- Collapse pre-existing duplicates so the partial unique index can be created.
+-- For each file_path with multiple pending/retry rows, keep the most recently
+-- updated row and drop the rest. Merge the longest can_process and any existing
+-- hash into the survivor so upgrading doesn't shorten settle timers or discard
+-- hash validation. This is the historical state #369 created before the dedupe
+-- logic landed; without it, the CREATE INDEX below would fail on any
+-- installation that already accumulated duplicates.
+UPDATE scan_events AS survivor
+SET
+  can_process = (
+    SELECT MAX(duplicate.can_process)
+    FROM scan_events AS duplicate
+    WHERE duplicate.file_path = survivor.file_path
+      AND duplicate.process_status IN ('pending', 'retry')
+  ),
+  file_hash = COALESCE(
+    survivor.file_hash,
+    (
+      SELECT duplicate.file_hash
+      FROM scan_events AS duplicate
+      WHERE duplicate.file_path = survivor.file_path
+        AND duplicate.process_status IN ('pending', 'retry')
+        AND duplicate.file_hash IS NOT NULL
+      ORDER BY duplicate.updated_at DESC, duplicate.id DESC
+      LIMIT 1
+    )
+  )
+WHERE survivor.process_status IN ('pending', 'retry')
+  AND 1 < (
+    SELECT COUNT(*)
+    FROM scan_events AS duplicate
+    WHERE duplicate.file_path = survivor.file_path
+      AND duplicate.process_status IN ('pending', 'retry')
+  );
+
+DELETE FROM scan_events
+WHERE process_status IN ('pending', 'retry')
+  AND id NOT IN (
+    SELECT id FROM (
+      SELECT id, ROW_NUMBER() OVER (
+        PARTITION BY file_path ORDER BY updated_at DESC, id DESC
+      ) AS rn
+      FROM scan_events
+      WHERE process_status IN ('pending', 'retry')
+    ) ranked
+    WHERE rn = 1
+  );
+
+-- Partial unique index: enforces "at most one non-terminal row per file_path"
+-- at the DB level and gives the upsert path a deterministic conflict target.
+-- Terminal rows (complete, failed) remain unconstrained so processing
+-- history is preserved across cleanups.
+CREATE UNIQUE INDEX idx_scan_events_dedupe_pending_retry
+  ON scan_events (file_path)
+  WHERE process_status IN ('pending', 'retry');

--- a/crates/database/migrations/postgres/2026-05-30-000001_dedupe_pending_partial_index/up.sql
+++ b/crates/database/migrations/postgres/2026-05-30-000001_dedupe_pending_partial_index/up.sql
@@ -1,10 +1,6 @@
--- Collapse pre-existing duplicates so the partial unique index can be created.
--- For each file_path with multiple pending/retry rows, keep the most recently
--- updated row and drop the rest. Merge the longest can_process and any existing
--- hash into the survivor so upgrading doesn't shorten settle timers or discard
--- hash validation. This is the historical state #369 created before the dedupe
--- logic landed; without it, the CREATE INDEX below would fail on any
--- installation that already accumulated duplicates.
+-- Old installs may already have duplicate queued rows. Merge the values we
+-- care about before deleting extras so upgrades don't shorten waits or drop
+-- hashes.
 UPDATE scan_events AS survivor
 SET
   can_process = (
@@ -46,10 +42,7 @@ WHERE process_status IN ('pending', 'retry')
     WHERE rn = 1
   );
 
--- Partial unique index: enforces "at most one non-terminal row per file_path"
--- at the DB level and gives the upsert path a deterministic conflict target.
--- Terminal rows (complete, failed) remain unconstrained so processing
--- history is preserved across cleanups.
+-- Keep one queued row per path while leaving complete/failed history alone.
 CREATE UNIQUE INDEX idx_scan_events_dedupe_pending_retry
   ON scan_events (file_path)
   WHERE process_status IN ('pending', 'retry');

--- a/crates/database/migrations/sqlite/2026-05-30-000001_dedupe_pending_partial_index/down.sql
+++ b/crates/database/migrations/sqlite/2026-05-30-000001_dedupe_pending_partial_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_scan_events_dedupe_pending_retry;

--- a/crates/database/migrations/sqlite/2026-05-30-000001_dedupe_pending_partial_index/up.sql
+++ b/crates/database/migrations/sqlite/2026-05-30-000001_dedupe_pending_partial_index/up.sql
@@ -1,0 +1,55 @@
+-- Collapse pre-existing duplicates so the partial unique index can be created.
+-- For each file_path with multiple pending/retry rows, keep the most recently
+-- updated row and drop the rest. Merge the longest can_process and any existing
+-- hash into the survivor so upgrading doesn't shorten settle timers or discard
+-- hash validation. This is the historical state #369 created before the dedupe
+-- logic landed; without it, the CREATE INDEX below would fail on any
+-- installation that already accumulated duplicates.
+UPDATE scan_events AS survivor
+SET
+  can_process = (
+    SELECT MAX(duplicate.can_process)
+    FROM scan_events AS duplicate
+    WHERE duplicate.file_path = survivor.file_path
+      AND duplicate.process_status IN ('pending', 'retry')
+  ),
+  file_hash = COALESCE(
+    survivor.file_hash,
+    (
+      SELECT duplicate.file_hash
+      FROM scan_events AS duplicate
+      WHERE duplicate.file_path = survivor.file_path
+        AND duplicate.process_status IN ('pending', 'retry')
+        AND duplicate.file_hash IS NOT NULL
+      ORDER BY duplicate.updated_at DESC, duplicate.id DESC
+      LIMIT 1
+    )
+  )
+WHERE survivor.process_status IN ('pending', 'retry')
+  AND 1 < (
+    SELECT COUNT(*)
+    FROM scan_events AS duplicate
+    WHERE duplicate.file_path = survivor.file_path
+      AND duplicate.process_status IN ('pending', 'retry')
+  );
+
+DELETE FROM scan_events
+WHERE process_status IN ('pending', 'retry')
+  AND id NOT IN (
+    SELECT id FROM (
+      SELECT id, ROW_NUMBER() OVER (
+        PARTITION BY file_path ORDER BY updated_at DESC, id DESC
+      ) AS rn
+      FROM scan_events
+      WHERE process_status IN ('pending', 'retry')
+    ) ranked
+    WHERE rn = 1
+  );
+
+-- Partial unique index: enforces "at most one non-terminal row per file_path"
+-- at the DB level and gives the upsert path a deterministic conflict target.
+-- Terminal rows (complete, failed) remain unconstrained so processing
+-- history is preserved across cleanups.
+CREATE UNIQUE INDEX idx_scan_events_dedupe_pending_retry
+  ON scan_events (file_path)
+  WHERE process_status IN ('pending', 'retry');

--- a/crates/database/migrations/sqlite/2026-05-30-000001_dedupe_pending_partial_index/up.sql
+++ b/crates/database/migrations/sqlite/2026-05-30-000001_dedupe_pending_partial_index/up.sql
@@ -1,10 +1,6 @@
--- Collapse pre-existing duplicates so the partial unique index can be created.
--- For each file_path with multiple pending/retry rows, keep the most recently
--- updated row and drop the rest. Merge the longest can_process and any existing
--- hash into the survivor so upgrading doesn't shorten settle timers or discard
--- hash validation. This is the historical state #369 created before the dedupe
--- logic landed; without it, the CREATE INDEX below would fail on any
--- installation that already accumulated duplicates.
+-- Old installs may already have duplicate queued rows. Merge the values we
+-- care about before deleting extras so upgrades don't shorten waits or drop
+-- hashes.
 UPDATE scan_events AS survivor
 SET
   can_process = (
@@ -46,10 +42,7 @@ WHERE process_status IN ('pending', 'retry')
     WHERE rn = 1
   );
 
--- Partial unique index: enforces "at most one non-terminal row per file_path"
--- at the DB level and gives the upsert path a deterministic conflict target.
--- Terminal rows (complete, failed) remain unconstrained so processing
--- history is preserved across cleanups.
+-- Keep one queued row per path while leaving complete/failed history alone.
 CREATE UNIQUE INDEX idx_scan_events_dedupe_pending_retry
   ON scan_events (file_path)
   WHERE process_status IN ('pending', 'retry');

--- a/crates/database/src/conn.rs
+++ b/crates/database/src/conn.rs
@@ -205,13 +205,7 @@ impl AnyConnection {
         }
     }
 
-    /// Atomic dedupe-on-insert backed by the partial unique index
-    /// `idx_scan_events_dedupe_pending_retry`. If a non-terminal row
-    /// (Pending or Retry) exists for the same `file_path`, its
-    /// `updated_at` is refreshed and `can_process` becomes
-    /// `MAX(existing, incoming)` so a longer wait from one trigger is
-    /// never shortened by another. `event_source` and `found_status`
-    /// are first-write-wins; `file_hash` is first-non-null-wins.
+    /// Inserts a queued event, or updates the existing pending/retry row for the path.
     pub fn upsert_pending(
         &mut self,
         ev: &NewScanEvent,
@@ -240,11 +234,8 @@ fn upsert_pending_pg(
     use diesel::upsert::{excluded, DecoratableTarget};
     use diesel::ExpressionMethods;
 
-    // Postgres requires the conflict target's WHERE clause to match
-    // the partial unique index — otherwise inference fails with
-    // "no unique or exclusion constraint matching the ON CONFLICT
-    // specification". Keep this covered by a real Postgres execution
-    // test before changing the predicate shape.
+    // Keep this predicate aligned with the partial index; Postgres checks that
+    // match at runtime, and the smoke test covers it.
     let pending: String = ProcessStatus::Pending.into();
     let retry: String = ProcessStatus::Retry.into();
 
@@ -279,11 +270,8 @@ fn upsert_pending_sqlite(
     use diesel::{ExpressionMethods, QueryDsl};
     use diesel::{OptionalExtension, SelectableHelper};
 
-    // SQLite cannot express `ON CONFLICT (file_path) WHERE …` through
-    // Diesel 2.3.9 — the typed `QueryFragment<Sqlite, _>` impl for
-    // `DecoratedConflictTarget` simply doesn't exist. The SQLite pool
-    // is capped at one connection, so this SELECT-then-write sequence is
-    // serialized at connection acquisition and cannot race itself.
+    // Diesel cannot target SQLite partial indexes here. The SQLite pool has one
+    // connection, so this select-and-write sequence is serialized.
     let pending: String = ProcessStatus::Pending.into();
     let retry: String = ProcessStatus::Retry.into();
 

--- a/crates/database/src/conn.rs
+++ b/crates/database/src/conn.rs
@@ -204,6 +204,113 @@ impl AnyConnection {
                 .map_err(Into::into),
         }
     }
+
+    /// Atomic dedupe-on-insert backed by the partial unique index
+    /// `idx_scan_events_dedupe_pending_retry`. If a non-terminal row
+    /// (Pending or Retry) exists for the same `file_path`, its
+    /// `updated_at` is refreshed and `can_process` becomes
+    /// `MAX(existing, incoming)` so a longer wait from one trigger is
+    /// never shortened by another. `event_source` and `found_status`
+    /// are first-write-wins; `file_hash` is first-non-null-wins.
+    pub fn upsert_pending(
+        &mut self,
+        ev: &NewScanEvent,
+        now: chrono::NaiveDateTime,
+    ) -> anyhow::Result<ScanEvent> {
+        match self {
+            #[cfg(feature = "postgres")]
+            Self::Postgresql(conn) => upsert_pending_pg(conn, ev, now),
+            #[cfg(feature = "sqlite")]
+            Self::Sqlite(conn) => upsert_pending_sqlite(conn, ev, now),
+        }
+    }
+}
+
+#[cfg(feature = "postgres")]
+fn upsert_pending_pg(
+    conn: &mut diesel::PgConnection,
+    ev: &NewScanEvent,
+    now: chrono::NaiveDateTime,
+) -> anyhow::Result<ScanEvent> {
+    use crate::models::ProcessStatus;
+    use crate::schema::scan_events::dsl::{
+        can_process, file_hash, file_path, process_status, updated_at,
+    };
+    use diesel::dsl::case_when;
+    use diesel::upsert::{excluded, DecoratableTarget};
+    use diesel::ExpressionMethods;
+
+    // Postgres requires the conflict target's WHERE clause to match
+    // the partial unique index — otherwise inference fails with
+    // "no unique or exclusion constraint matching the ON CONFLICT
+    // specification". Keep this covered by a real Postgres execution
+    // test before changing the predicate shape.
+    let pending: String = ProcessStatus::Pending.into();
+    let retry: String = ProcessStatus::Retry.into();
+
+    diesel::insert_into(crate::schema::scan_events::table)
+        .values(ev)
+        .on_conflict(file_path)
+        .filter_target(process_status.eq_any([pending, retry]))
+        .do_update()
+        .set((
+            updated_at.eq(now),
+            can_process.eq(
+                case_when(can_process.lt(excluded(can_process)), excluded(can_process))
+                    .otherwise(can_process),
+            ),
+            file_hash.eq(case_when(file_hash.is_null(), excluded(file_hash)).otherwise(file_hash)),
+        ))
+        .returning(ScanEvent::as_returning())
+        .get_result::<ScanEvent>(conn)
+        .map_err(Into::into)
+}
+
+#[cfg(feature = "sqlite")]
+fn upsert_pending_sqlite(
+    conn: &mut diesel::SqliteConnection,
+    ev: &NewScanEvent,
+    now: chrono::NaiveDateTime,
+) -> anyhow::Result<ScanEvent> {
+    use crate::models::ProcessStatus;
+    use crate::schema::scan_events::dsl::{
+        can_process, file_hash, file_path, process_status, scan_events, updated_at,
+    };
+    use diesel::{ExpressionMethods, QueryDsl};
+    use diesel::{OptionalExtension, SelectableHelper};
+
+    // SQLite cannot express `ON CONFLICT (file_path) WHERE …` through
+    // Diesel 2.3.9 — the typed `QueryFragment<Sqlite, _>` impl for
+    // `DecoratedConflictTarget` simply doesn't exist. The SQLite pool
+    // is capped at one connection, so this SELECT-then-write sequence is
+    // serialized at connection acquisition and cannot race itself.
+    let pending: String = ProcessStatus::Pending.into();
+    let retry: String = ProcessStatus::Retry.into();
+
+    let existing: Option<ScanEvent> = scan_events
+        .filter(file_path.eq(&ev.file_path))
+        .filter(process_status.eq_any([pending, retry]))
+        .first::<ScanEvent>(conn)
+        .optional()?;
+
+    if let Some(existing) = existing {
+        let later_can_process = std::cmp::max(existing.can_process, ev.can_process);
+        let file_hash_value = existing.file_hash.clone().or_else(|| ev.file_hash.clone());
+        diesel::update(&existing)
+            .set((
+                updated_at.eq(now),
+                can_process.eq(later_can_process),
+                file_hash.eq(file_hash_value),
+            ))
+            .get_result::<ScanEvent>(conn)
+            .map_err(Into::into)
+    } else {
+        diesel::insert_into(crate::schema::scan_events::table)
+            .values(ev)
+            .returning(ScanEvent::as_returning())
+            .get_result::<ScanEvent>(conn)
+            .map_err(Into::into)
+    }
 }
 
 #[doc(hidden)]
@@ -244,10 +351,16 @@ pub fn get_pool(database_url: &String) -> anyhow::Result<Pool<ConnectionManager<
 
     let manager = ConnectionManager::<AnyConnection>::new(database_url);
 
-    Pool::builder()
-        .connection_customizer(Box::new(AcquireHook::default()))
-        .build(manager)
-        .context("failed to create pool")
+    let builder = Pool::builder().connection_customizer(Box::new(AcquireHook::default()));
+
+    #[cfg(feature = "sqlite")]
+    let builder = if database_url.starts_with("sqlite://") {
+        builder.max_size(1)
+    } else {
+        builder
+    };
+
+    builder.build(manager).context("failed to create pool")
 }
 
 #[cfg(test)]
@@ -323,5 +436,101 @@ mod tests {
         let shm_path = tmp.path().join("test.db-shm");
         assert!(!wal_path.exists(), "WAL file should be cleaned up");
         assert!(!shm_path.exists(), "SHM file should be cleaned up");
+    }
+
+    #[test]
+    #[cfg(feature = "sqlite")]
+    fn dedupe_migration_merges_max_can_process_into_survivor() {
+        use crate::models::ProcessStatus;
+        use crate::schema::scan_events::dsl::{file_path, process_status, scan_events};
+        use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
+        use diesel::{ExpressionMethods, QueryDsl, RunQueryDsl};
+
+        let tmp = tempdir().unwrap();
+        let db_path = tmp.path().join("test.db");
+        let url = format!("sqlite://{}", db_path.display());
+
+        AnyConnection::pre_init(&url).unwrap();
+        let pool = get_pool(&url).unwrap();
+        let mut conn = get_conn(&pool).unwrap();
+
+        conn.batch_execute(
+            r#"
+            CREATE TABLE scan_events (
+                id TEXT PRIMARY KEY NOT NULL,
+                event_source TEXT NOT NULL,
+                event_timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                file_path TEXT NOT NULL,
+                file_hash TEXT,
+                process_status TEXT NOT NULL DEFAULT 'pending',
+                found_status TEXT NOT NULL DEFAULT 'not_found',
+                failed_times INTEGER DEFAULT 0 NOT NULL,
+                next_retry_at TIMESTAMP,
+                targets_hit TEXT DEFAULT '' NOT NULL,
+                found_at TIMESTAMP,
+                processed_at TIMESTAMP,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                can_process TIMESTAMP NOT NULL DEFAULT "2024-10-14T12:00:00.000"
+            );
+
+            CREATE TABLE __diesel_schema_migrations (
+                version VARCHAR(50) PRIMARY KEY NOT NULL,
+                run_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+
+            INSERT INTO __diesel_schema_migrations (version) VALUES
+                ('20240829125750'),
+                ('20240905143749'),
+                ('20240906161345'),
+                ('20241012130403'),
+                ('20241205114327'),
+                ('20241205115656'),
+                ('202512300005460000'),
+                ('20260519000001');
+
+            INSERT INTO scan_events (
+                id, event_source, file_path, file_hash, process_status,
+                updated_at, created_at, event_timestamp, can_process
+            ) VALUES
+                (
+                    'older-long-wait', 'sonarr', '/media/migrate.mkv', 'sha256:migrate', 'pending',
+                    '2026-01-01 00:00:00', '2026-01-01 00:00:00',
+                    '2026-01-01 00:00:00', '2026-01-01 03:00:00'
+                ),
+                (
+                    'newer-short-wait', 'notify', '/media/migrate.mkv', NULL, 'retry',
+                    '2026-01-01 01:00:00', '2026-01-01 01:00:00',
+                    '2026-01-01 01:00:00', '2026-01-01 02:00:00'
+                );
+            "#,
+        )
+        .unwrap();
+
+        conn.migrate().unwrap();
+
+        let pending: String = ProcessStatus::Pending.into();
+        let retry: String = ProcessStatus::Retry.into();
+        let rows = scan_events
+            .filter(file_path.eq("/media/migrate.mkv"))
+            .filter(process_status.eq_any([pending, retry]))
+            .load::<ScanEvent>(&mut conn)
+            .unwrap();
+
+        assert_eq!(rows.len(), 1, "migration should leave one non-terminal row");
+        assert_eq!(rows[0].id, "newer-short-wait", "newest row should survive");
+        assert_eq!(
+            rows[0].can_process,
+            NaiveDateTime::new(
+                NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
+                NaiveTime::from_hms_opt(3, 0, 0).unwrap(),
+            ),
+            "survivor should inherit the duplicate group's longest wait"
+        );
+        assert_eq!(
+            rows[0].file_hash,
+            Some("sha256:migrate".to_string()),
+            "survivor should inherit a duplicate's hash when it has none"
+        );
     }
 }

--- a/crates/service/Cargo.toml
+++ b/crates/service/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2021"
 version.workspace = true
 
 [features]
+sqlite = ["autopulse-database/sqlite"]
+postgres = ["autopulse-database/postgres"]
 vendored = []
 
 [dependencies]

--- a/crates/service/src/lib.rs
+++ b/crates/service/src/lib.rs
@@ -11,5 +11,6 @@ mod tests {
     mod manager_add_event;
     mod targets;
     mod triggers;
+    #[cfg(feature = "sqlite")]
     pub mod util;
 }

--- a/crates/service/src/lib.rs
+++ b/crates/service/src/lib.rs
@@ -8,6 +8,8 @@ pub mod settings;
 
 #[cfg(test)]
 mod tests {
+    mod manager_add_event;
     mod targets;
     mod triggers;
+    pub mod util;
 }

--- a/crates/service/src/manager.rs
+++ b/crates/service/src/manager.rs
@@ -7,8 +7,7 @@ use crate::settings::Settings;
 use autopulse_database::diesel::sql_types::{BigInt, Text};
 use autopulse_database::diesel::QueryableByName;
 use autopulse_database::schema::scan_events::{
-    can_process, created_at, event_source, file_path, id, next_retry_at, processed_at, targets_hit,
-    updated_at,
+    created_at, event_source, file_path, id, next_retry_at, processed_at, targets_hit, updated_at,
 };
 use autopulse_database::{
     conn::{get_conn, DbPool},
@@ -176,32 +175,18 @@ impl PulseManager {
     }
 
     pub fn add_event(&self, ev: &NewScanEvent) -> anyhow::Result<ScanEvent> {
-        // Dedupe condition (issue #369): if a non-terminal row exists
-        // for the same file_path (Pending or Retry), refresh it
-        // instead of inserting. Terminal states (Complete, Failed)
-        // intentionally do NOT coalesce — a new arrival on a finished
-        // row is genuinely new work. Original event_source preserved
-        // (first-write-wins); we only bump can_process (later of the
-        // two so timer extensions from a second trigger win) and
-        // updated_at. found_status is never touched here — the
-        // runner's verification is authoritative.
-        let pending: String = ProcessStatus::Pending.into();
-        let retry: String = ProcessStatus::Retry.into();
-        let existing = scan_events
-            .filter(file_path.eq(&ev.file_path))
-            .filter(process_status.eq_any(vec![pending, retry]))
-            .first::<ScanEvent>(&mut get_conn(&self.pool)?)
-            .ok();
-
-        let result = if let Some(existing) = existing {
-            let now = chrono::Utc::now().naive_utc();
-            let later_can_process = std::cmp::max(existing.can_process, ev.can_process);
-            diesel::update(&existing)
-                .set((updated_at.eq(now), can_process.eq(later_can_process)))
-                .get_result::<ScanEvent>(&mut get_conn(&self.pool)?)?
-        } else {
-            get_conn(&self.pool)?.insert_and_return(ev)?
-        };
+        // Dedupe (issue #369): a non-terminal row (Pending or Retry)
+        // for the same `file_path` is updated in place via the partial
+        // unique index `idx_scan_events_dedupe_pending_retry`. Terminal
+        // rows (Complete, Failed) are not covered by the index, so a
+        // new arrival after a finished row produces a fresh insert.
+        // Single atomic statement — no SELECT-then-INSERT race window.
+        // Coalesce semantics: `event_source`, `found_status`, and
+        // `file_hash` are first-write-wins; `can_process` becomes
+        // `MAX(existing, incoming)` so a longer wait from one trigger
+        // is never shortened by another.
+        let now = chrono::Utc::now().naive_utc();
+        let result = get_conn(&self.pool)?.upsert_pending(ev, now)?;
 
         self.publish(EventType::New, &result);
 

--- a/crates/service/src/manager.rs
+++ b/crates/service/src/manager.rs
@@ -175,16 +175,6 @@ impl PulseManager {
     }
 
     pub fn add_event(&self, ev: &NewScanEvent) -> anyhow::Result<ScanEvent> {
-        // Dedupe (issue #369): a non-terminal row (Pending or Retry)
-        // for the same `file_path` is updated in place via the partial
-        // unique index `idx_scan_events_dedupe_pending_retry`. Terminal
-        // rows (Complete, Failed) are not covered by the index, so a
-        // new arrival after a finished row produces a fresh insert.
-        // Single atomic statement — no SELECT-then-INSERT race window.
-        // Coalesce semantics: `event_source`, `found_status`, and
-        // `file_hash` are first-write-wins; `can_process` becomes
-        // `MAX(existing, incoming)` so a longer wait from one trigger
-        // is never shortened by another.
         let now = chrono::Utc::now().naive_utc();
         let result = get_conn(&self.pool)?.upsert_pending(ev, now)?;
 

--- a/crates/service/src/manager.rs
+++ b/crates/service/src/manager.rs
@@ -17,7 +17,7 @@ use autopulse_database::{
         TextExpressionMethods,
     },
     models::{FoundStatus, NewScanEvent, ProcessStatus, ScanEvent},
-    schema::scan_events::{dsl::scan_events, found_status, process_status},
+    schema::scan_events::{dsl::scan_events, process_status},
 };
 use notify_debouncer_full::notify;
 use serde::Serialize;
@@ -176,22 +176,28 @@ impl PulseManager {
     }
 
     pub fn add_event(&self, ev: &NewScanEvent) -> anyhow::Result<ScanEvent> {
-        let mut check = scan_events
+        // Dedupe condition (issue #369): if a non-terminal row exists
+        // for the same file_path (Pending or Retry), refresh it
+        // instead of inserting. Terminal states (Complete, Failed)
+        // intentionally do NOT coalesce — a new arrival on a finished
+        // row is genuinely new work. Original event_source preserved
+        // (first-write-wins); we only bump can_process (later of the
+        // two so timer extensions from a second trigger win) and
+        // updated_at. found_status is never touched here — the
+        // runner's verification is authoritative.
+        let pending: String = ProcessStatus::Pending.into();
+        let retry: String = ProcessStatus::Retry.into();
+        let existing = scan_events
             .filter(file_path.eq(&ev.file_path))
-            .filter(process_status.eq::<String>(ProcessStatus::Pending.into()))
-            .filter(event_source.eq(&ev.event_source))
-            .into_boxed();
+            .filter(process_status.eq_any(vec![pending, retry]))
+            .first::<ScanEvent>(&mut get_conn(&self.pool)?)
+            .ok();
 
-        if ev.found_status == FoundStatus::Found.to_string() {
-            check = check.filter(found_status.eq(&ev.found_status));
-        }
-
-        let result = if let Ok(existing) = check.first::<ScanEvent>(&mut get_conn(&self.pool)?) {
+        let result = if let Some(existing) = existing {
+            let now = chrono::Utc::now().naive_utc();
+            let later_can_process = std::cmp::max(existing.can_process, ev.can_process);
             diesel::update(&existing)
-                .set((
-                    updated_at.eq(chrono::Utc::now().naive_utc()),
-                    can_process.eq(ev.can_process),
-                ))
+                .set((updated_at.eq(now), can_process.eq(later_can_process)))
                 .get_result::<ScanEvent>(&mut get_conn(&self.pool)?)?
         } else {
             get_conn(&self.pool)?.insert_and_return(ev)?

--- a/crates/service/src/tests/manager_add_event.rs
+++ b/crates/service/src/tests/manager_add_event.rs
@@ -45,6 +45,26 @@ fn dedupe_keeps_the_later_can_process_time() {
 }
 
 #[test]
+fn dedupe_never_shortens_can_process_time() {
+    // Long-then-short ordering: the second arrival must NOT shorten
+    // the wait the first trigger set. Covered by GREATEST/max in the
+    // upsert; without that, the new value would win and shorten the
+    // schedule by 50 seconds in this fixture.
+    let m = fresh_manager("dedupe-no-shorten");
+    let first = m
+        .add_event(&new_event("sonarr", "/media/long.mkv", 60))
+        .unwrap();
+    let second = m
+        .add_event(&new_event("notify", "/media/long.mkv", 10))
+        .unwrap();
+    assert_eq!(first.id, second.id, "must coalesce");
+    assert_eq!(
+        second.can_process, first.can_process,
+        "longer wait must survive a shorter follow-up"
+    );
+}
+
+#[test]
 fn dedupe_does_not_regress_found_status() {
     let m = fresh_manager("dedupe-found");
     let mut found = new_event("sonarr", "/media/c.mkv", 30);

--- a/crates/service/src/tests/manager_add_event.rs
+++ b/crates/service/src/tests/manager_add_event.rs
@@ -1,0 +1,214 @@
+use crate::tests::util::fresh_manager;
+use crate::{manager::PulseManager, settings::Settings};
+use autopulse_database::conn::get_conn;
+use autopulse_database::conn::get_pool;
+use autopulse_database::models::{FoundStatus, NewScanEvent, ProcessStatus};
+use chrono::{Duration, Utc};
+use std::sync::{Arc, Barrier};
+
+fn new_event(source: &str, path: &str, can_process_secs: i64) -> NewScanEvent {
+    NewScanEvent {
+        event_source: source.to_string(),
+        file_path: path.to_string(),
+        can_process: Utc::now().naive_utc() + Duration::seconds(can_process_secs),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn dedupes_pending_event_across_triggers_with_same_path() {
+    let m = fresh_manager("dedupe-cross-source");
+    let a = m
+        .add_event(&new_event("sonarr", "/media/a.mkv", 30))
+        .unwrap();
+    let b = m
+        .add_event(&new_event("notify", "/media/a.mkv", 30))
+        .unwrap();
+    assert_eq!(
+        a.id, b.id,
+        "second add for same pending path must return original row"
+    );
+    assert_eq!(b.event_source, "sonarr", "original event_source preserved");
+}
+
+#[test]
+fn dedupe_keeps_the_later_can_process_time() {
+    let m = fresh_manager("dedupe-can-process");
+    let first = m
+        .add_event(&new_event("sonarr", "/media/b.mkv", 10))
+        .unwrap();
+    let second = m
+        .add_event(&new_event("notify", "/media/b.mkv", 60))
+        .unwrap();
+    assert!(second.can_process >= first.can_process);
+    assert!(second.can_process > Utc::now().naive_utc() + Duration::seconds(30));
+}
+
+#[test]
+fn dedupe_does_not_regress_found_status() {
+    let m = fresh_manager("dedupe-found");
+    let mut found = new_event("sonarr", "/media/c.mkv", 30);
+    found.found_status = FoundStatus::Found.into();
+    let inserted = m.add_event(&found).unwrap();
+    assert_eq!(inserted.found_status, "found");
+
+    let notfound = new_event("notify", "/media/c.mkv", 30);
+    let after = m.add_event(&notfound).unwrap();
+    assert_eq!(
+        after.found_status, "found",
+        "must not downgrade found→not_found on coalesce"
+    );
+}
+
+#[test]
+fn dedupe_preserves_later_file_hash_when_existing_row_has_none() {
+    let m = fresh_manager("dedupe-file-hash");
+    let first = m
+        .add_event(&new_event("notify", "/media/hash.mkv", 30))
+        .unwrap();
+    assert_eq!(first.file_hash, None);
+
+    let mut with_hash = new_event("manual", "/media/hash.mkv", 30);
+    with_hash.file_hash = Some("sha256:abc123".to_string());
+    let after = m.add_event(&with_hash).unwrap();
+
+    assert_eq!(after.id, first.id, "same pending path should coalesce");
+    assert_eq!(
+        after.file_hash,
+        Some("sha256:abc123".to_string()),
+        "a later hash should fill an empty existing hash"
+    );
+}
+
+#[test]
+fn concurrent_same_path_add_event_coalesces_without_unique_errors() {
+    const THREADS: usize = 32;
+
+    for attempt in 0..8 {
+        let m = fresh_manager(&format!("dedupe-concurrent-{attempt}"));
+        let barrier = Arc::new(Barrier::new(THREADS));
+        let mut handles = Vec::with_capacity(THREADS);
+
+        for thread in 0..THREADS {
+            let m = m.clone();
+            let barrier = barrier.clone();
+            handles.push(std::thread::spawn(move || {
+                barrier.wait();
+                m.add_event(&new_event(
+                    &format!("source-{thread}"),
+                    "/media/concurrent.mkv",
+                    thread as i64,
+                ))
+            }));
+        }
+
+        let mut ids = vec![];
+        for handle in handles {
+            ids.push(
+                handle
+                    .join()
+                    .expect("worker thread should not panic")
+                    .unwrap()
+                    .id,
+            );
+        }
+
+        ids.sort();
+        ids.dedup();
+        assert_eq!(ids.len(), 1, "all concurrent callers should get one row id");
+    }
+}
+
+#[test]
+fn postgres_upsert_conflict_target_matches_partial_index() {
+    let Ok(url) = std::env::var("AUTOPULSE_TEST_POSTGRES_URL") else {
+        return;
+    };
+
+    let pool = get_pool(&url).expect("postgres test database pool should initialize");
+    get_conn(&pool)
+        .expect("postgres test database connection should initialize")
+        .migrate()
+        .expect("postgres test database migrations should apply");
+
+    let mut settings = Settings::default();
+    settings.app.database_url = url;
+    let m = PulseManager::new(settings, pool);
+    let unique_path = format!(
+        "/media/postgres-{}.mkv",
+        Utc::now()
+            .timestamp_nanos_opt()
+            .expect("current timestamp should fit in nanos")
+    );
+
+    let first = m.add_event(&new_event("sonarr", &unique_path, 30)).unwrap();
+    let second = m.add_event(&new_event("notify", &unique_path, 60)).unwrap();
+
+    assert_eq!(first.id, second.id, "postgres upsert should coalesce");
+    assert!(second.can_process > first.can_process);
+}
+
+#[test]
+fn retry_event_coalesces_with_new_arrival() {
+    let m = fresh_manager("dedupe-retry");
+    let inserted = m
+        .add_event(&new_event("sonarr", "/media/r.mkv", 30))
+        .unwrap();
+
+    // Simulate the runner moving the row into Retry.
+    use autopulse_database::diesel::{self, ExpressionMethods, QueryDsl, RunQueryDsl};
+    use autopulse_database::schema::scan_events::dsl::{process_status, scan_events};
+    diesel::update(scan_events.find(&inserted.id))
+        .set(process_status.eq::<String>(ProcessStatus::Retry.into()))
+        .execute(&mut get_conn(&m.pool).unwrap())
+        .unwrap();
+
+    let again = m
+        .add_event(&new_event("notify", "/media/r.mkv", 60))
+        .unwrap();
+    assert_eq!(
+        again.id, inserted.id,
+        "Retry row must coalesce per user decision"
+    );
+    assert!(again.can_process > inserted.can_process);
+}
+
+#[test]
+fn completed_event_does_not_coalesce_with_new_event() {
+    let m = fresh_manager("dedupe-complete");
+    let inserted = m
+        .add_event(&new_event("sonarr", "/media/d.mkv", 0))
+        .unwrap();
+
+    use autopulse_database::diesel::{self, ExpressionMethods, QueryDsl, RunQueryDsl};
+    use autopulse_database::schema::scan_events::dsl::{process_status, scan_events};
+    diesel::update(scan_events.find(&inserted.id))
+        .set(process_status.eq::<String>(ProcessStatus::Complete.into()))
+        .execute(&mut get_conn(&m.pool).unwrap())
+        .unwrap();
+
+    let again = m
+        .add_event(&new_event("notify", "/media/d.mkv", 0))
+        .unwrap();
+    assert_ne!(again.id, inserted.id, "completed row must not be reopened");
+}
+
+#[test]
+fn failed_event_does_not_coalesce_with_new_event() {
+    let m = fresh_manager("dedupe-failed");
+    let inserted = m
+        .add_event(&new_event("sonarr", "/media/e.mkv", 0))
+        .unwrap();
+
+    use autopulse_database::diesel::{self, ExpressionMethods, QueryDsl, RunQueryDsl};
+    use autopulse_database::schema::scan_events::dsl::{process_status, scan_events};
+    diesel::update(scan_events.find(&inserted.id))
+        .set(process_status.eq::<String>(ProcessStatus::Failed.into()))
+        .execute(&mut get_conn(&m.pool).unwrap())
+        .unwrap();
+
+    let again = m
+        .add_event(&new_event("notify", "/media/e.mkv", 0))
+        .unwrap();
+    assert_ne!(again.id, inserted.id, "failed row must not be reopened");
+}

--- a/crates/service/src/tests/manager_add_event.rs
+++ b/crates/service/src/tests/manager_add_event.rs
@@ -56,10 +56,6 @@ fn dedupe_keeps_the_later_can_process_time() {
 #[test]
 #[cfg(feature = "sqlite")]
 fn dedupe_never_shortens_can_process_time() {
-    // Long-then-short ordering: the second arrival must NOT shorten
-    // the wait the first trigger set. Covered by GREATEST/max in the
-    // upsert; without that, the new value would win and shorten the
-    // schedule by 50 seconds in this fixture.
     let m = fresh_manager("dedupe-no-shorten");
     let first = m
         .add_event(&new_event("sonarr", "/media/long.mkv", 60))
@@ -190,7 +186,7 @@ fn retry_event_coalesces_with_new_arrival() {
         .add_event(&new_event("sonarr", "/media/r.mkv", 30))
         .unwrap();
 
-    // Simulate the runner moving the row into Retry.
+    // Match the state the runner sets before retrying.
     use autopulse_database::diesel::{self, ExpressionMethods, QueryDsl, RunQueryDsl};
     use autopulse_database::schema::scan_events::dsl::{process_status, scan_events};
     diesel::update(scan_events.find(&inserted.id))

--- a/crates/service/src/tests/manager_add_event.rs
+++ b/crates/service/src/tests/manager_add_event.rs
@@ -1,9 +1,16 @@
+#[cfg(feature = "sqlite")]
 use crate::tests::util::fresh_manager;
+#[cfg(feature = "postgres")]
 use crate::{manager::PulseManager, settings::Settings};
+#[cfg(any(feature = "postgres", feature = "sqlite"))]
 use autopulse_database::conn::get_conn;
+#[cfg(feature = "postgres")]
 use autopulse_database::conn::get_pool;
-use autopulse_database::models::{FoundStatus, NewScanEvent, ProcessStatus};
+use autopulse_database::models::NewScanEvent;
+#[cfg(feature = "sqlite")]
+use autopulse_database::models::{FoundStatus, ProcessStatus};
 use chrono::{Duration, Utc};
+#[cfg(feature = "sqlite")]
 use std::sync::{Arc, Barrier};
 
 fn new_event(source: &str, path: &str, can_process_secs: i64) -> NewScanEvent {
@@ -16,6 +23,7 @@ fn new_event(source: &str, path: &str, can_process_secs: i64) -> NewScanEvent {
 }
 
 #[test]
+#[cfg(feature = "sqlite")]
 fn dedupes_pending_event_across_triggers_with_same_path() {
     let m = fresh_manager("dedupe-cross-source");
     let a = m
@@ -32,6 +40,7 @@ fn dedupes_pending_event_across_triggers_with_same_path() {
 }
 
 #[test]
+#[cfg(feature = "sqlite")]
 fn dedupe_keeps_the_later_can_process_time() {
     let m = fresh_manager("dedupe-can-process");
     let first = m
@@ -45,6 +54,7 @@ fn dedupe_keeps_the_later_can_process_time() {
 }
 
 #[test]
+#[cfg(feature = "sqlite")]
 fn dedupe_never_shortens_can_process_time() {
     // Long-then-short ordering: the second arrival must NOT shorten
     // the wait the first trigger set. Covered by GREATEST/max in the
@@ -65,6 +75,7 @@ fn dedupe_never_shortens_can_process_time() {
 }
 
 #[test]
+#[cfg(feature = "sqlite")]
 fn dedupe_does_not_regress_found_status() {
     let m = fresh_manager("dedupe-found");
     let mut found = new_event("sonarr", "/media/c.mkv", 30);
@@ -81,6 +92,7 @@ fn dedupe_does_not_regress_found_status() {
 }
 
 #[test]
+#[cfg(feature = "sqlite")]
 fn dedupe_preserves_later_file_hash_when_existing_row_has_none() {
     let m = fresh_manager("dedupe-file-hash");
     let first = m
@@ -101,6 +113,7 @@ fn dedupe_preserves_later_file_hash_when_existing_row_has_none() {
 }
 
 #[test]
+#[cfg(feature = "sqlite")]
 fn concurrent_same_path_add_event_coalesces_without_unique_errors() {
     const THREADS: usize = 32;
 
@@ -140,6 +153,7 @@ fn concurrent_same_path_add_event_coalesces_without_unique_errors() {
 }
 
 #[test]
+#[cfg(feature = "postgres")]
 fn postgres_upsert_conflict_target_matches_partial_index() {
     let Ok(url) = std::env::var("AUTOPULSE_TEST_POSTGRES_URL") else {
         return;
@@ -169,6 +183,7 @@ fn postgres_upsert_conflict_target_matches_partial_index() {
 }
 
 #[test]
+#[cfg(feature = "sqlite")]
 fn retry_event_coalesces_with_new_arrival() {
     let m = fresh_manager("dedupe-retry");
     let inserted = m
@@ -194,6 +209,7 @@ fn retry_event_coalesces_with_new_arrival() {
 }
 
 #[test]
+#[cfg(feature = "sqlite")]
 fn completed_event_does_not_coalesce_with_new_event() {
     let m = fresh_manager("dedupe-complete");
     let inserted = m
@@ -214,6 +230,7 @@ fn completed_event_does_not_coalesce_with_new_event() {
 }
 
 #[test]
+#[cfg(feature = "sqlite")]
 fn failed_event_does_not_coalesce_with_new_event() {
     let m = fresh_manager("dedupe-failed");
     let inserted = m

--- a/crates/service/src/tests/util.rs
+++ b/crates/service/src/tests/util.rs
@@ -1,7 +1,3 @@
-//! Shared test utilities. Currently: a freshly-migrated `PulseManager`
-//! backed by a unique on-disk SQLite database. Mirrors the existing
-//! `crates/server/src/tests/routes/public_endpoints.rs` pattern.
-
 use crate::manager::PulseManager;
 use crate::settings::Settings;
 use autopulse_database::conn::{get_conn, get_pool};

--- a/crates/service/src/tests/util.rs
+++ b/crates/service/src/tests/util.rs
@@ -1,0 +1,32 @@
+//! Shared test utilities. Currently: a freshly-migrated `PulseManager`
+//! backed by a unique on-disk SQLite database. Mirrors the existing
+//! `crates/server/src/tests/routes/public_endpoints.rs` pattern.
+
+use crate::manager::PulseManager;
+use crate::settings::Settings;
+use autopulse_database::conn::{get_conn, get_pool};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+pub fn unique_db_url(scope: &str) -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock should be after unix epoch")
+        .as_nanos();
+    let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("sqlite:///tmp/autopulse-service-{scope}-{nanos}-{seq}.db")
+}
+
+pub fn fresh_manager(scope: &str) -> PulseManager {
+    let url = unique_db_url(scope);
+    let mut settings = Settings::default();
+    settings.app.database_url = url.clone();
+    let pool = get_pool(&url).expect("test database pool should initialize");
+    get_conn(&pool)
+        .expect("test database connection should initialize")
+        .migrate()
+        .expect("test database migrations should apply");
+    PulseManager::new(settings, pool)
+}


### PR DESCRIPTION
# Description

When two triggers report the same file before it has been processed, autopulse now keeps one queued scan event instead of piling up duplicate work and retries.

Existing queued duplicates are cleaned up during the migration. If duplicates already exist, autopulse keeps the newest queued row while carrying over the longest wait time and any file hash that was already present.

Resolves #369

## Type of change

- [ ] Bug (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (addition or change to documentation)