### PR TITLE
fix(ci): speed up binary builds

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -6,8 +6,7 @@ permissions:
 on:
   release:
     types: [published]
-  pull_request:
-    branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: continuous-delivery-${{ github.ref }}
@@ -142,4 +141,4 @@ jobs:
           zip: windows
           features: ${{ (contains(matrix.target, '-musl') || startsWith(matrix.os, 'windows')) && 'vendored' || '' }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          dry-run: ${{ github.event_name == 'pull_request' }}
+          dry-run: ${{ github.event_name != 'release' }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1160,21 +1160,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1535,22 +1520,6 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
  "tower-service",
 ]
 
@@ -2068,23 +2037,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "notify"
 version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2168,32 +2120,6 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
-name = "openssl"
-version = "0.10.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
-dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "openssl-probe"
@@ -2591,12 +2517,10 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -2607,7 +2531,6 @@ dependencies = [
  "serde_json",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -3317,16 +3240,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,11 @@ version.workspace = true
 version = "1.7.0"
 
 [features]
-vendored = ["autopulse-service/vendored", "autopulse-database/vendored"]
+vendored = ["autopulse-service/vendored", "postgres-vendored", "sqlite-vendored"]
 sqlite = ["autopulse-database/sqlite", "autopulse-server/sqlite"]
 postgres = ["autopulse-database/postgres", "autopulse-server/postgres"]
+sqlite-vendored = ["sqlite", "autopulse-database/sqlite-vendored"]
+postgres-vendored = ["postgres", "autopulse-database/postgres-vendored"]
 default = ["sqlite", "postgres"]
 
 [dependencies]

--- a/crates/database/Cargo.toml
+++ b/crates/database/Cargo.toml
@@ -7,8 +7,15 @@ version.workspace = true
 
 [features]
 postgres = ["diesel/postgres", "diesel_migrations/postgres", "dep:pq-sys"]
-sqlite = ["diesel/sqlite", "diesel_migrations/sqlite", "dep:libsqlite3-sys"]
-vendored = ["pq-sys/bundled", "libsqlite3-sys/bundled", "openssl-sys/vendored"]
+sqlite = [
+    "diesel/sqlite",
+    "diesel/returning_clauses_for_sqlite_3_35",
+    "diesel_migrations/sqlite",
+    "dep:libsqlite3-sys",
+]
+postgres-vendored = ["postgres", "pq-sys/bundled", "openssl-sys/vendored"]
+sqlite-vendored = ["sqlite", "libsqlite3-sys/bundled"]
+vendored = ["postgres-vendored", "sqlite-vendored"]
 
 [dependencies]
 # Crates
@@ -22,7 +29,6 @@ chrono = { workspace = true }
 
 # Database
 diesel = { version = "2.3.6", default-features = false, features = [
-    "returning_clauses_for_sqlite_3_35",
     "r2d2",
     "chrono",
 ] }

--- a/crates/service/Cargo.toml
+++ b/crates/service/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 version.workspace = true
 
 [features]
-vendored = ["reqwest/native-tls-vendored"]
+vendored = []
 
 [dependencies]
 # Crates
@@ -22,7 +22,14 @@ tokio = { workspace = true, features = ["macros", "process"] }
 futures = { workspace = true }
 
 # HTTP client
-reqwest = { version = "0.13.0", features = ["json", "stream"] }
+reqwest = { version = "0.13.0", default-features = false, features = [
+    "charset",
+    "http2",
+    "json",
+    "rustls",
+    "stream",
+    "system-proxy",
+] }
 
 # Credential encoding
 base64 = "0.22.1"


### PR DESCRIPTION
# Description

Stops the full binary release matrix from running on every PR and keeps it for releases/manual dry-runs. Also trims some unnecessary release-build work by splitting vendored DB features and using one reqwest TLS stack.

## Type of change

- [x] Bug (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (addition or change to documentation)