### PR TITLE
fix(settings): simplify config defaults

### DIFF
--- a/crates/server/src/routes/config.rs
+++ b/crates/server/src/routes/config.rs
@@ -5,9 +5,8 @@ use autopulse_service::manager::PulseManager;
 use autopulse_service::settings::app::App;
 use autopulse_service::settings::targets::{Target, TargetType};
 use autopulse_service::settings::triggers::{Trigger, TriggerType};
-use autopulse_service::settings::{default_triggers, Settings};
+use autopulse_service::settings::Settings;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 
 fn default_database_type() -> DatabaseType {
     DatabaseType::default()
@@ -113,7 +112,10 @@ fn generate_config_template(
         ..Default::default()
     };
 
-    let mut triggers = default_triggers();
+    let mut settings = Settings {
+        app,
+        ..Default::default()
+    };
 
     for trigger in input_triggers {
         let name = serde_json::to_string(trigger)?.replace('"', "");
@@ -121,13 +123,13 @@ fn generate_config_template(
         let mut count = 0;
         let mut key = name.clone();
 
-        while triggers.contains_key(&key) {
+        while settings.triggers.contains_key(&key) {
             count += 1;
 
             key = format!("{}_{}", name, count);
         }
 
-        triggers.insert(
+        settings.triggers.insert(
             key,
             match trigger {
                 TriggerType::Manual => Trigger::Manual(serde_json::from_str(r#"{}"#)?),
@@ -144,20 +146,18 @@ fn generate_config_template(
         );
     }
 
-    let mut targets = HashMap::new();
-
     for target in input_targets {
         let name = serde_json::to_string(target)?.replace('"', "");
         let mut count = 0;
         let mut key = name.clone();
 
-        while targets.contains_key(&key) {
+        while settings.targets.contains_key(&key) {
             count += 1;
 
             key = format!("{}_{}", name, count);
         }
 
-        targets.insert(
+        settings.targets.insert(
             key,
             match target {
                 TargetType::Plex => Target::Plex(serde_json::from_str(
@@ -179,7 +179,7 @@ fn generate_config_template(
                     r#"{"url": "{url}", "token": "{token}"}"#,
                 )?),
                 TargetType::Command => Target::Command(serde_json::from_str(
-                    r#"{"command": "echo 'Processing {path}'"}"#,
+                    r#"{"raw": "echo 'Processing $FILE_PATH'"}"#,
                 )?),
                 TargetType::FileFlows => {
                     Target::FileFlows(serde_json::from_str(r#"{"url": "{url}"}"#)?)
@@ -193,13 +193,6 @@ fn generate_config_template(
             },
         );
     }
-
-    let settings = Settings {
-        app,
-        triggers,
-        targets,
-        ..Default::default()
-    };
 
     let app_config = match output_type {
         OutputType::Json => serde_json::to_string_pretty(&settings)?,
@@ -324,5 +317,57 @@ mod tests {
         assert!(config_str.contains("manual_1"));
         assert!(config_str.contains("plex"));
         assert!(config_str.contains("plex_1"));
+    }
+
+    #[test]
+    fn generated_json_command_template_round_trips_with_a_runnable_command() {
+        let triggers = vec![];
+        let targets = vec![TargetType::Command];
+        let result = generate_config_template(
+            &DatabaseType::default(),
+            &triggers,
+            &targets,
+            &OutputType::Json,
+        )
+        .unwrap();
+
+        let response = serde_json::to_value(&result).unwrap();
+        let config_str = response["config"].as_str().unwrap();
+        let settings: Settings = serde_json::from_str(config_str).unwrap();
+
+        let Some(Target::Command(command)) = settings.targets.get("command") else {
+            panic!("expected generated command target");
+        };
+
+        assert!(
+            command.raw.is_some() || command.path.is_some(),
+            "generated command target must be runnable"
+        );
+    }
+
+    #[test]
+    fn generated_toml_command_template_round_trips_with_a_runnable_command() {
+        let triggers = vec![];
+        let targets = vec![TargetType::Command];
+        let result = generate_config_template(
+            &DatabaseType::default(),
+            &triggers,
+            &targets,
+            &OutputType::Toml,
+        )
+        .unwrap();
+
+        let response = serde_json::to_value(&result).unwrap();
+        let config_str = response["config"].as_str().unwrap();
+        let settings: Settings = toml::from_str(config_str).unwrap();
+
+        let Some(Target::Command(command)) = settings.targets.get("command") else {
+            panic!("expected generated command target");
+        };
+
+        assert!(
+            command.raw.is_some() || command.path.is_some(),
+            "generated command target must be runnable"
+        );
     }
 }

--- a/crates/service/src/settings/app.rs
+++ b/crates/service/src/settings/app.rs
@@ -2,26 +2,6 @@ use autopulse_utils::LogLevel;
 use serde::{Deserialize, Serialize};
 use std::net::IpAddr;
 
-#[doc(hidden)]
-fn default_hostname() -> String {
-    "0.0.0.0".to_string()
-}
-
-#[doc(hidden)]
-const fn default_port() -> u16 {
-    2875
-}
-
-#[doc(hidden)]
-fn default_database_url() -> String {
-    autopulse_database::conn::DatabaseType::default().default_url()
-}
-
-#[doc(hidden)]
-fn default_log_level() -> LogLevel {
-    LogLevel::default()
-}
-
 /// Normalize `base_path` so `format!("{base}/ui/...")` is always well-formed:
 /// either `""` or `/<prefix>`, no trailing slash. Tests cover the corner cases.
 fn normalize_base_path<'de, D>(deserializer: D) -> Result<String, D::Error>
@@ -71,10 +51,10 @@ pub struct App {
 impl Default for App {
     fn default() -> Self {
         Self {
-            hostname: default_hostname(),
-            port: default_port(),
-            database_url: default_database_url(),
-            log_level: default_log_level(),
+            hostname: "0.0.0.0".to_string(),
+            port: 2875,
+            database_url: autopulse_database::conn::DatabaseType::default().default_url(),
+            log_level: LogLevel::default(),
             api_logging: false,
             base_path: String::new(),
             secure_cookies: false,

--- a/crates/service/src/settings/app.rs
+++ b/crates/service/src/settings/app.rs
@@ -41,36 +41,30 @@ where
 }
 
 #[derive(Serialize, Deserialize, Clone)]
+#[serde(default)]
 pub struct App {
     /// Hostname to bind to, (default: 0.0.0.0)
-    #[serde(default = "default_hostname")]
     pub hostname: String,
     /// Port to bind to (default: 2875)
-    #[serde(default = "default_port")]
     pub port: u16,
     /// Database URL (see [`AnyConnection`](autopulse_database::conn::AnyConnection))
-    #[serde(default = "default_database_url")]
     pub database_url: String,
     /// Log level (default: info) (trace, debug, info, warn, error)
-    #[serde(default = "default_log_level")]
     pub log_level: LogLevel,
     /// Whether to include api logging (default: false)
-    #[serde(default)]
     pub api_logging: bool,
     /// Reverse-proxy base path (default: ""). UI routes are mounted under
     /// this prefix server-side and generated links include it, so the
     /// proxy should pass the prefix through verbatim (no strip-prefix).
     /// Input is normalized: leading slash added if missing, trailing
     /// slash stripped, `"/"` collapses to `""`.
-    #[serde(default, deserialize_with = "normalize_base_path")]
+    #[serde(deserialize_with = "normalize_base_path")]
     pub base_path: String,
     /// Whether to set the `Secure` flag on the UI session cookie
     /// (default: false). Enable when serving over HTTPS/TLS.
-    #[serde(default)]
     pub secure_cookies: bool,
     /// Proxy IPs whose `X-Forwarded-For` we honor for the login throttle's
     /// client identification. Empty (default) = trust nothing, use `peer_addr`.
-    #[serde(default)]
     pub trusted_proxies: Vec<IpAddr>,
 }
 

--- a/crates/service/src/settings/auth.rs
+++ b/crates/service/src/settings/auth.rs
@@ -17,16 +17,14 @@ const fn default_enabled() -> bool {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(default)]
 pub struct Auth {
     /// Whether authentication is enabled (default: true)
-    #[serde(default = "default_enabled")]
     #[serde(skip_serializing)]
     pub enabled: bool,
     /// Username for basic auth (default: admin)
-    #[serde(default = "default_username")]
     pub username: String,
     /// Password for basic auth (default: password)
-    #[serde(default = "default_password")]
     pub password: String,
 }
 

--- a/crates/service/src/settings/auth.rs
+++ b/crates/service/src/settings/auth.rs
@@ -1,21 +1,6 @@
 use base64::prelude::*;
 use serde::{Deserialize, Serialize};
 
-#[doc(hidden)]
-fn default_username() -> String {
-    "admin".to_string()
-}
-
-#[doc(hidden)]
-fn default_password() -> String {
-    "password".to_string()
-}
-
-#[doc(hidden)]
-const fn default_enabled() -> bool {
-    true
-}
-
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(default)]
 pub struct Auth {
@@ -31,9 +16,9 @@ pub struct Auth {
 impl Default for Auth {
     fn default() -> Self {
         Self {
-            enabled: default_enabled(),
-            username: default_username(),
-            password: default_password(),
+            enabled: true,
+            username: "admin".to_string(),
+            password: "password".to_string(),
         }
     }
 }

--- a/crates/service/src/settings/mod.rs
+++ b/crates/service/src/settings/mod.rs
@@ -114,22 +114,17 @@ pub fn default_triggers() -> HashMap<String, Trigger> {
 }
 
 #[derive(Serialize, Deserialize, Clone)]
+#[serde(default)]
 pub struct Settings {
-    #[serde(default)]
     pub app: App,
 
-    #[serde(default)]
     pub auth: Auth,
 
-    #[serde(default)]
     pub opts: Opts,
 
-    #[serde(default = "default_triggers")]
     pub triggers: HashMap<String, Trigger>,
-    #[serde(default)]
     pub targets: HashMap<String, Target>,
 
-    #[serde(default)]
     pub webhooks: HashMap<String, Webhook>,
 
     /// List of paths to anchor the service to
@@ -143,7 +138,6 @@ pub struct Settings {
     ///  - /mnt/media/tv # Directory
     ///  - /mnt/media/anchor # File
     /// ```
-    #[serde(default)]
     pub anchors: Vec<PathBuf>,
 }
 
@@ -322,7 +316,7 @@ impl Settings {
         }
 
         let mut settings: Self = fig.extract().map_err(|e| anyhow::anyhow!(e))?;
-        settings.add_default_manual_trigger()?;
+        settings.normalize()?;
 
         Ok(LoadedSettings {
             settings,
@@ -341,6 +335,12 @@ impl Settings {
             self.webhooks.len(),
             self.anchors.len(),
         );
+    }
+
+    pub fn normalize(&mut self) -> anyhow::Result<()> {
+        self.add_default_manual_trigger()?;
+
+        Ok(())
     }
 
     pub fn add_default_manual_trigger(&mut self) -> anyhow::Result<()> {
@@ -450,5 +450,36 @@ mod tests {
                 .contains("failed to read file referenced by AUTOPULSE__AUTH__PASSWORD__FILE"),
             "{err:?}"
         );
+    }
+
+    #[test]
+    fn empty_settings_deserialize_like_rust_default() {
+        let settings: Settings = serde_json::from_str("{}").expect("empty settings should load");
+        let default = Settings::default();
+
+        assert_eq!(
+            serde_json::to_value(&settings).expect("settings serialize"),
+            serde_json::to_value(&default).expect("default settings serialize")
+        );
+        assert_eq!(settings.auth.enabled, default.auth.enabled);
+        assert!(matches!(
+            settings.triggers.get("manual"),
+            Some(Trigger::Manual(_))
+        ));
+    }
+
+    #[test]
+    fn normalize_adds_manual_trigger_to_present_empty_trigger_map() {
+        let mut settings: Settings =
+            serde_json::from_str(r#"{"triggers":{}}"#).expect("settings should load");
+
+        assert!(!settings.triggers.contains_key("manual"));
+
+        settings.normalize().expect("settings should normalize");
+
+        assert!(matches!(
+            settings.triggers.get("manual"),
+            Some(Trigger::Manual(_))
+        ));
     }
 }

--- a/crates/service/src/settings/opts.rs
+++ b/crates/service/src/settings/opts.rs
@@ -2,41 +2,6 @@ use autopulse_utils::Rotation;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-#[doc(hidden)]
-const fn default_check_path() -> bool {
-    false
-}
-
-#[doc(hidden)]
-const fn default_max_retries() -> i32 {
-    5
-}
-
-#[doc(hidden)]
-const fn default_default_timer_wait() -> u64 {
-    60
-}
-
-#[doc(hidden)]
-const fn default_cleanup_days() -> u64 {
-    10
-}
-
-#[doc(hidden)]
-const fn default_webhook_retries() -> u8 {
-    3
-}
-
-#[doc(hidden)]
-const fn default_webhook_timeout() -> u64 {
-    10
-}
-
-#[doc(hidden)]
-const fn default_webhook_interval() -> u64 {
-    10
-}
-
 #[derive(Serialize, Clone, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum LogRotation {
@@ -104,15 +69,15 @@ pub struct Opts {
 impl Default for Opts {
     fn default() -> Self {
         Self {
-            check_path: default_check_path(),
-            max_retries: default_max_retries(),
-            default_timer_wait: default_default_timer_wait(),
-            cleanup_days: default_cleanup_days(),
+            check_path: false,
+            max_retries: 5,
+            default_timer_wait: 60,
+            cleanup_days: 10,
             log_file: None,
             log_file_rollover: LogRotation::default(),
-            webhook_retries: default_webhook_retries(),
-            webhook_timeout: default_webhook_timeout(),
-            webhook_interval: default_webhook_interval(),
+            webhook_retries: 3,
+            webhook_timeout: 10,
+            webhook_interval: 10,
         }
     }
 }

--- a/crates/service/src/settings/opts.rs
+++ b/crates/service/src/settings/opts.rs
@@ -71,40 +71,33 @@ impl From<&LogRotation> for Rotation {
 }
 
 #[derive(Serialize, Deserialize, Clone)]
+#[serde(default)]
 pub struct Opts {
     /// Check if the path exists before processing (default: false)
-    #[serde(default = "default_check_path")]
     pub check_path: bool,
 
     /// Maximum retries before giving up (default: 5)
-    #[serde(default = "default_max_retries")]
     pub max_retries: i32,
 
     /// Default timer wait time (default: 60)
-    #[serde(default = "default_default_timer_wait")]
     pub default_timer_wait: u64,
 
     /// Cleanup not_found events older than x days (default: 10)
-    #[serde(default = "default_cleanup_days")]
     pub cleanup_days: u64,
 
     /// Log file path
     pub log_file: Option<PathBuf>,
 
     /// Whether to rollover the log file (default: never)
-    #[serde(default)]
     pub log_file_rollover: LogRotation,
 
     /// Number of retries for webhook HTTP requests (default: 3)
-    #[serde(default = "default_webhook_retries")]
     pub webhook_retries: u8,
 
     /// HTTP timeout in seconds for webhook requests (default: 10)
-    #[serde(default = "default_webhook_timeout")]
     pub webhook_timeout: u64,
 
     /// Interval in seconds between webhook batch sends (default: 10)
-    #[serde(default = "default_webhook_interval")]
     pub webhook_interval: u64,
 }
 

--- a/crates/service/src/settings/targets/command.rs
+++ b/crates/service/src/settings/targets/command.rs
@@ -35,6 +35,10 @@ impl Command {
             return Err(anyhow::anyhow!("command cannot have both path and raw"));
         }
 
+        if self.path.is_none() && self.raw.is_none() {
+            return Err(anyhow::anyhow!("command requires either path or raw"));
+        }
+
         let ev_path = ev.get_path(&self.rewrite);
 
         if let Some(path) = self.path.clone() {
@@ -98,5 +102,55 @@ impl TargetProcess for Command {
         }
 
         Ok(succeeded)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Command;
+    use autopulse_database::models::ScanEvent;
+
+    fn scan_event() -> ScanEvent {
+        let now = chrono::Utc::now().naive_utc();
+
+        ScanEvent {
+            id: "event-id".to_string(),
+            event_source: "manual".to_string(),
+            event_timestamp: now,
+            file_path: "/media/movie.mkv".to_string(),
+            file_hash: None,
+            process_status: "pending".to_string(),
+            found_status: "found".to_string(),
+            failed_times: 0,
+            next_retry_at: None,
+            targets_hit: String::new(),
+            found_at: None,
+            processed_at: None,
+            created_at: now,
+            updated_at: now,
+            can_process: now,
+        }
+    }
+
+    #[tokio::test]
+    async fn run_rejects_command_without_path_or_raw() {
+        let command = Command {
+            path: None,
+            timeout: None,
+            raw: None,
+            rewrite: None,
+            filter: Default::default(),
+        };
+
+        let err = command
+            .run(&scan_event())
+            .await
+            .expect_err("empty command target should fail");
+
+        assert!(
+            err.to_string()
+                .contains("command requires either path or raw"),
+            "unexpected error: {err}"
+        );
     }
 }


### PR DESCRIPTION
# Description

Makes Rust `Default` the single source for core config defaults, with a small cleanup step after loading to keep the built-in `manual` trigger present.

Also fixes the generated command target example so it creates a real command instead of a no-op, and makes empty command targets fail instead of silently succeeding.

## Type of change

- [x] Bug (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (addition or change to documentation)