### PR TITLE
feat(logging): limit retained log files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,6 +481,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "tempfile",
  "tokio",
  "tracing-appender",
  "tracing-subscriber",

--- a/crates/service/src/settings/opts.rs
+++ b/crates/service/src/settings/opts.rs
@@ -85,15 +85,3 @@ impl Default for Opts {
         }
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn log_file_max_files_defaults_to_30() {
-        let opts: Opts = serde_json::from_str("{}").expect("empty opts should deserialize");
-
-        assert_eq!(opts.log_file_max_files, 30);
-    }
-}

--- a/crates/service/src/settings/opts.rs
+++ b/crates/service/src/settings/opts.rs
@@ -56,6 +56,9 @@ pub struct Opts {
     /// Whether to rollover the log file (default: never)
     pub log_file_rollover: LogRotation,
 
+    /// Maximum number of log files to retain (default: 30)
+    pub log_file_max_files: usize,
+
     /// Number of retries for webhook HTTP requests (default: 3)
     pub webhook_retries: u8,
 
@@ -75,9 +78,22 @@ impl Default for Opts {
             cleanup_days: 10,
             log_file: None,
             log_file_rollover: LogRotation::default(),
+            log_file_max_files: 30,
             webhook_retries: 3,
             webhook_timeout: 10,
             webhook_interval: 10,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn log_file_max_files_defaults_to_30() {
+        let opts: Opts = serde_json::from_str("{}").expect("empty opts should deserialize");
+
+        assert_eq!(opts.log_file_max_files, 30);
     }
 }

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -6,6 +6,7 @@ version.workspace = true
 
 [dev-dependencies]
 serde_json = { workspace = true }
+tempfile = "3"
 
 [dependencies]
 # Core

--- a/crates/utils/src/logs.rs
+++ b/crates/utils/src/logs.rs
@@ -113,8 +113,8 @@ fn rolling_file_appender(
         .ok_or_else(|| anyhow::anyhow!("failed to get parent directory of log file"))?;
     let filename = log_file
         .file_name()
-        .and_then(|name| name.to_str())
         .ok_or_else(|| anyhow::anyhow!("failed to get file name of log file"))?;
+    let filename = filename.to_string_lossy();
 
     RollingFileAppender::builder()
         .rotation(rotation.clone())
@@ -160,5 +160,20 @@ mod tests {
             .count();
 
         assert_eq!(retained_logs, 30);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rolling_appender_accepts_non_utf8_log_filenames() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let directory = tempfile::tempdir().expect("temp directory should be created");
+        let filename = OsString::from_vec(b"autopulse-\xff.log".to_vec());
+        let log_file = directory.path().join(filename);
+
+        let appender = rolling_file_appender(&log_file, &Rotation::NEVER, 30)
+            .expect("appender should accept a non-UTF-8 filename");
+        drop(appender);
     }
 }

--- a/crates/utils/src/logs.rs
+++ b/crates/utils/src/logs.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Ok};
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_appender::rolling::RollingFileAppender;
 pub use tracing_appender::rolling::Rotation;
@@ -49,6 +49,7 @@ pub fn setup_logs(
     log_level: &LogLevel,
     log_file: &Option<PathBuf>,
     log_file_rollover: &Rotation,
+    log_file_max_files: usize,
     api_logging: bool,
 ) -> anyhow::Result<Option<WorkerGuard>> {
     let timer = tracing_subscriber::fmt::time::OffsetTime::local_rfc_3339()
@@ -73,15 +74,7 @@ pub fn setup_logs(
         // suffix and rotation boundary track the local timezone instead of
         // UTC. Without that feature, log filenames would be a day off the
         // record timestamps inside them (#208).
-        let writer = RollingFileAppender::new(
-            log_file_rollover.clone(),
-            log_file
-                .parent()
-                .ok_or_else(|| anyhow::anyhow!("failed to get parent directory of log file"))?,
-            log_file
-                .file_name()
-                .ok_or_else(|| anyhow::anyhow!("failed to get file name of log file"))?,
-        );
+        let writer = rolling_file_appender(log_file, log_file_rollover, log_file_max_files)?;
 
         let (non_blocking, guard) = tracing_appender::non_blocking(writer);
         file_guard = Some(guard);
@@ -108,4 +101,64 @@ pub fn setup_logs(
         registry.with(console_layer).init();
     }
     Ok(file_guard)
+}
+
+fn rolling_file_appender(
+    log_file: &Path,
+    rotation: &Rotation,
+    max_log_files: usize,
+) -> anyhow::Result<RollingFileAppender> {
+    let directory = log_file
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("failed to get parent directory of log file"))?;
+    let filename = log_file
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| anyhow::anyhow!("failed to get file name of log file"))?;
+
+    RollingFileAppender::builder()
+        .rotation(rotation.clone())
+        .filename_prefix(filename)
+        .max_log_files(max_log_files)
+        .build(directory)
+        .context("failed to initialize rolling file appender")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn rolling_appender_prunes_files_beyond_the_configured_limit() {
+        let directory = tempfile::tempdir().expect("temp directory should be created");
+        let log_file = directory.path().join("autopulse.log");
+
+        for day in 1..=31 {
+            fs::write(
+                directory
+                    .path()
+                    .join(format!("autopulse.log.2020-01-{day:02}")),
+                "old log",
+            )
+            .expect("old log should be created");
+        }
+
+        let appender = rolling_file_appender(&log_file, &Rotation::DAILY, 30)
+            .expect("appender should be created");
+        drop(appender);
+
+        let retained_logs = fs::read_dir(directory.path())
+            .expect("log directory should be readable")
+            .filter_map(Result::ok)
+            .filter(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with("autopulse.log")
+            })
+            .count();
+
+        assert_eq!(retained_logs, 30);
+    }
 }

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -12,6 +12,9 @@
 # opts:
   # check_path: true # Check if the path exists, assuming the path is available to the container
   # max_retries: 5 # Exponential backoff when a target fails
+  # log_file: /app/logs/autopulse.log
+  # log_file_rollover: daily
+  # log_file_max_files: 30 # Maximum number of log files to retain
 
 # triggers:
   # sonarr:

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use anyhow::Context;
 use autopulse_database::conn::{close_pool, get_conn, get_pool, AnyConnection};
 use autopulse_server::get_server;
 use autopulse_service::manager::PulseManager;
-use autopulse_service::settings::Settings;
+use autopulse_service::settings::{opts::Opts, Settings};
 use autopulse_utils::tracing_appender::non_blocking::WorkerGuard;
 use autopulse_utils::{setup_logs, Rotation};
 use clap::Parser;
@@ -149,7 +149,7 @@ fn setup() -> anyhow::Result<(Settings, Option<WorkerGuard>)> {
                 &autopulse_utils::LogLevel::Info,
                 &None,
                 &Rotation::NEVER,
-                30,
+                Opts::default().log_file_max_files,
                 false,
             )?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,6 +137,7 @@ fn setup() -> anyhow::Result<(Settings, Option<WorkerGuard>)> {
                 &loaded.settings.app.log_level,
                 &loaded.settings.opts.log_file,
                 &log_file_rollover,
+                loaded.settings.opts.log_file_max_files,
                 loaded.settings.app.api_logging,
             )?;
             loaded.log_diagnostics();
@@ -148,6 +149,7 @@ fn setup() -> anyhow::Result<(Settings, Option<WorkerGuard>)> {
                 &autopulse_utils::LogLevel::Info,
                 &None,
                 &Rotation::NEVER,
+                30,
                 false,
             )?;
 


### PR DESCRIPTION
# Description

Adds `log_file_max_files` under `opts` to limit how many rolled log files are kept. Defaults to 30 and prunes matching old logs when autopulse starts and whenever the log rolls over.

## Type of change

- [ ] Bug (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (addition or change to documentation)