### PR TITLE
feat(ci): unify nix builds

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -1,0 +1,24 @@
+name: Setup cached Nix
+description: Share Nix build artifacts between checks, documentation, images, and releases
+inputs:
+  cache-name:
+    description: Distinguishes concurrent cache writers
+    required: true
+  github-token:
+    description: Token for authenticated Nix input downloads
+    required: true
+runs:
+  using: composite
+  steps:
+    - uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
+      with:
+        github_access_token: ${{ inputs.github-token }}
+        extra_nix_config: |
+          keep-outputs = true
+    - uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7
+      with:
+        primary-key: nix-${{ runner.arch }}-${{ hashFiles('flake.lock', 'flake.nix', 'nix/**/*.nix', 'Cargo.lock', 'rust-toolchain.toml') }}-${{ github.sha }}-${{ inputs.cache-name }}
+        restore-prefixes-first-match: |
+          nix-${{ runner.arch }}-${{ hashFiles('flake.lock', 'flake.nix', 'nix/**/*.nix', 'Cargo.lock', 'rust-toolchain.toml') }}-
+          nix-${{ runner.arch }}-
+        restore-prefixes-all-matches: nix-${{ runner.arch }}-${{ hashFiles('flake.lock', 'flake.nix', 'nix/**/*.nix', 'Cargo.lock', 'rust-toolchain.toml') }}-${{ github.sha }}-

--- a/.github/workflows/continuous-delivery-docker.yml
+++ b/.github/workflows/continuous-delivery-docker.yml
@@ -37,9 +37,6 @@ jobs:
   
   build:
     name: Build - ${{ matrix.platform.name }} - ${{ matrix.feature }}
-    env:
-      SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: sccache
     strategy:
       matrix:
         feature:
@@ -49,11 +46,9 @@ jobs:
         platform:
           - name: linux/amd64
             runner: ubuntu-22.04
-            target: x86_64-unknown-linux-musl
             tag: -amd64
           - name: linux/arm64
             runner: ubuntu-22.04-arm
-            target: aarch64-unknown-linux-musl
             tag: -arm64
     runs-on: ${{ matrix.platform.runner }}
     steps:
@@ -61,11 +56,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      # - name: Set up QEMU
-      #   uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
+      - uses: ./.github/actions/setup-nix
+        with:
+          cache-name: image-${{ matrix.feature }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to the GHCR
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
@@ -80,27 +74,6 @@ jobs:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Extract metadata (labels)
-        id: meta
-        uses: docker/metadata-action@c3b064c6d7c32446d6bc214ea075f1caad2de35a
-        with:
-          images: ghcr.io/dan-online/autopulse,danonline/autopulse
-
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.11
-
-      - name: Cargo Cache
-        uses: actions/cache@v6
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-release-${{ matrix.platform.target }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-release-${{ matrix.platform.target }}-
 
       - name: Pull Request suffix
         run: |
@@ -117,68 +90,38 @@ jobs:
           fi
         id: tag
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.platform.target }}
-          components: rustfmt,clippy
-
-      - uses: taiki-e/setup-cross-toolchain-action@12b7ad4acfa95a1476779d6c06699b96ec1691f8 # v1
-        with:
-          target: ${{ matrix.platform.target }}
-
-      - name: Test binary
-        if: matrix.feature == 'full'
-        run: cargo test --locked --release --features vendored --target ${{ matrix.platform.target }} --workspace
-
-      - name: Build binary
-        if: matrix.feature == 'full'
-        run: cargo build --locked --release --features vendored --target ${{ matrix.platform.target }}
-
-      - name: Test binary
-        if: matrix.feature != 'full'
-        run: cargo test --locked --release --no-default-features --features vendored,${{ matrix.feature }} --target ${{ matrix.platform.target }} --workspace
-
-      - name: Build binary
-        if: matrix.feature != 'full'
-        run: cargo build --locked --release --no-default-features --features vendored,${{ matrix.feature }} --target ${{ matrix.platform.target }}
-
-      - name: Copy binary
+      - name: Build and test Nix image
         run: |
-          cp target/${{ matrix.platform.target }}/release/autopulse ./autopulse
+          system=$(nix eval --impure --raw --expr builtins.currentSystem)
+          nix build --no-update-lock-file --print-build-logs --no-link \
+            ".#checks.$system.test-${{ matrix.feature }}" \
+            ".#checks.$system.doctest-${{ matrix.feature }}"
+          nix build --no-update-lock-file --print-build-logs .#image-${{ matrix.feature }}
 
-          file ./autopulse
+      - name: Load and smoke-test image
+        run: |
+          docker load --input result
+          docker run --rm autopulse:${{ matrix.feature }} /bin/autopulse --help
 
-      # "latest-platform?" tag, full feature-set
-      - name: Create Docker Image
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
-        if: matrix.feature == 'full'
-        with:
-          push: true
-          context: .
-          tags: |
-            ghcr.io/dan-online/autopulse:${{ steps.tag.outputs.tag }}${{ matrix.platform.tag }}
-            danonline/autopulse:${{ steps.tag.outputs.tag }}${{ matrix.platform.tag }}
-            ${{ steps.tag.outputs.tag_stable && format('ghcr.io/dan-online/autopulse:{0}{1}', steps.tag.outputs.tag_stable, matrix.platform.tag) || '' }}
-            ${{ steps.tag.outputs.tag_stable && format('danonline/autopulse:{0}{1}', steps.tag.outputs.tag_stable, matrix.platform.tag) || '' }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: ${{ matrix.platform.name }}
-          build-args: ${{ matrix.platform.build_args }}
-
-      # "feature-platform?" tag, selected feature-set
-      - name: Build and push
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
-        if: matrix.feature != 'full'
-        with:
-          push: true
-          context: .
-          tags: |
-            ghcr.io/dan-online/autopulse:${{ steps.tag.outputs.tag }}-${{ matrix.feature }}${{ matrix.platform.tag }}
-            danonline/autopulse:${{ steps.tag.outputs.tag }}-${{ matrix.feature }}${{ matrix.platform.tag }}
-            ${{ steps.tag.outputs.tag_stable && format('ghcr.io/dan-online/autopulse:{0}-{1}{2}', steps.tag.outputs.tag_stable, matrix.feature, matrix.platform.tag) || '' }}
-            ${{ steps.tag.outputs.tag_stable && format('danonline/autopulse:{0}-{1}{2}', steps.tag.outputs.tag_stable, matrix.feature, matrix.platform.tag) || '' }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: ${{ matrix.platform.name }}
-          build-args: ${{ matrix.platform.build_args }}
+      - name: Push image
+        env:
+          FEATURE: ${{ matrix.feature }}
+          PLATFORM_SUFFIX: ${{ matrix.platform.tag }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          TAG_STABLE: ${{ steps.tag.outputs.tag_stable }}
+        run: |
+          FEATURE_SUFFIX=""
+          if [ "$FEATURE" != full ]; then
+            FEATURE_SUFFIX="-$FEATURE"
+          fi
+          for REPOSITORY in ghcr.io/dan-online/autopulse danonline/autopulse; do
+            for IMAGE_TAG in "$TAG" "$TAG_STABLE"; do
+              [ -n "$IMAGE_TAG" ] || continue
+              IMAGE="$REPOSITORY:$IMAGE_TAG$FEATURE_SUFFIX$PLATFORM_SUFFIX"
+              docker tag "autopulse:$FEATURE" "$IMAGE"
+              docker push "$IMAGE"
+            done
+          done
 
       
       
@@ -222,95 +165,22 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Create and push manifests
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+          TAG_STABLE: ${{ steps.tag.outputs.tag_stable }}
         run: |
           GHCR_BASE="ghcr.io/dan-online/autopulse"
-          DOCKERHUB_BASE="danonline/autopulse"
-          TAG="${{ steps.tag.outputs.tag }}"
-          TAG_STABLE="${{ steps.tag.outputs.tag_stable }}"
-          
-          # First, create and push all manifests to GHCR
-          # Get digests from GHCR only
-          AMD64_DIGEST=$(docker manifest inspect ${GHCR_BASE}:${TAG}-amd64 | jq -r '.manifests[0].digest')
-          ARM64_DIGEST=$(docker manifest inspect ${GHCR_BASE}:${TAG}-arm64 | jq -r '.manifests[0].digest')
-
-          POSTGRES_AMD64_DIGEST=$(docker manifest inspect ${GHCR_BASE}:${TAG}-postgres-amd64 | jq -r '.manifests[0].digest')
-          POSTGRES_ARM64_DIGEST=$(docker manifest inspect ${GHCR_BASE}:${TAG}-postgres-arm64 | jq -r '.manifests[0].digest')
-
-          SQLITE_AMD64_DIGEST=$(docker manifest inspect ${GHCR_BASE}:${TAG}-sqlite-amd64 | jq -r '.manifests[0].digest')
-          SQLITE_ARM64_DIGEST=$(docker manifest inspect ${GHCR_BASE}:${TAG}-sqlite-arm64 | jq -r '.manifests[0].digest')
-
-          # Build manifests on GHCR
-          echo "Creating manifests on GHCR..."
-          
-          # Main manifest
-          docker manifest create ${GHCR_BASE}:${TAG} \
-              --amend ${GHCR_BASE}@${AMD64_DIGEST} \
-              --amend ${GHCR_BASE}@${ARM64_DIGEST}
-          
-          # Postgres manifest
-          docker manifest create ${GHCR_BASE}:${TAG}-postgres \
-              --amend ${GHCR_BASE}@${POSTGRES_AMD64_DIGEST} \
-              --amend ${GHCR_BASE}@${POSTGRES_ARM64_DIGEST}
-          
-          # SQLite manifest
-          docker manifest create ${GHCR_BASE}:${TAG}-sqlite \
-              --amend ${GHCR_BASE}@${SQLITE_AMD64_DIGEST} \
-              --amend ${GHCR_BASE}@${SQLITE_ARM64_DIGEST}
-
-          docker manifest push ${GHCR_BASE}:${TAG}-postgres
-          docker manifest push ${GHCR_BASE}:${TAG}-sqlite
-          docker manifest push ${GHCR_BASE}:${TAG}
-
-          docker buildx imagetools create \
-            --tag danonline/autopulse:${TAG} \
-            ghcr.io/dan-online/autopulse:${TAG}
-
-          docker buildx imagetools create \
-            --tag danonline/autopulse:${TAG}-postgres \
-            ghcr.io/dan-online/autopulse:${TAG}-postgres
-
-          docker buildx imagetools create \
-            --tag danonline/autopulse:${TAG}-sqlite \
-            ghcr.io/dan-online/autopulse:${TAG}-sqlite
-          
-          if [ -n "$TAG_STABLE" ]; then
-            echo "Creating stable manifests..."
-            docker manifest create ${GHCR_BASE}:${TAG_STABLE} \
-                --amend ${GHCR_BASE}@${AMD64_DIGEST} \
-                --amend ${GHCR_BASE}@${ARM64_DIGEST}
-            docker manifest create ${GHCR_BASE}:${TAG_STABLE}-postgres \
-                --amend ${GHCR_BASE}@${POSTGRES_AMD64_DIGEST} \
-                --amend ${GHCR_BASE}@${POSTGRES_ARM64_DIGEST}
-            docker manifest create ${GHCR_BASE}:${TAG_STABLE}-sqlite \
-                --amend ${GHCR_BASE}@${SQLITE_AMD64_DIGEST} \
-                --amend ${GHCR_BASE}@${SQLITE_ARM64_DIGEST}
-
-            docker manifest push ${GHCR_BASE}:${TAG_STABLE}-postgres
-            docker manifest push ${GHCR_BASE}:${TAG_STABLE}-sqlite
-            docker manifest push ${GHCR_BASE}:${TAG_STABLE}
-
-            docker buildx imagetools create \
-              --tag danonline/autopulse:${TAG_STABLE} \
-              ghcr.io/dan-online/autopulse:${TAG_STABLE}
-
-            docker buildx imagetools create \
-              --tag danonline/autopulse:${TAG_STABLE}-postgres \
-              ghcr.io/dan-online/autopulse:${TAG_STABLE}-postgres
-
-            docker buildx imagetools create \
-              --tag danonline/autopulse:${TAG_STABLE}-sqlite \
-              ghcr.io/dan-online/autopulse:${TAG_STABLE}-sqlite
-          fi
-          
-          echo "Copy images over to Docker Hub..."
-          # docker pull ${GHCR_BASE}:${TAG} -q
-          # docker pull ${GHCR_BASE}:${TAG}-postgres -q
-          # docker pull ${GHCR_BASE}:${TAG}-sqlite -q
-
-          # docker tag ${GHCR_BASE}:${TAG} ${DOCKERHUB_BASE}:${TAG}
-          # docker tag ${GHCR_BASE}:${TAG}-postgres ${DOCKERHUB_BASE}:${TAG}-postgres
-          # docker tag ${GHCR_BASE}:${TAG}-sqlite ${DOCKERHUB_BASE}:${TAG}-sqlite
-          
-          # docker push ${DOCKERHUB_BASE}:${TAG}-postgres -q
-          # docker push ${DOCKERHUB_BASE}:${TAG}-sqlite -q
-          # docker push ${DOCKERHUB_BASE}:${TAG} -q
+          for FEATURE_SUFFIX in "" -postgres -sqlite; do
+            SOURCE="${GHCR_BASE}:${TAG}${FEATURE_SUFFIX}"
+            for IMAGE_TAG in "$TAG" "$TAG_STABLE"; do
+              [ -n "$IMAGE_TAG" ] || continue
+              DESTINATION="${GHCR_BASE}:${IMAGE_TAG}${FEATURE_SUFFIX}"
+              docker manifest create "$DESTINATION" \
+                --amend "${SOURCE}-amd64" \
+                --amend "${SOURCE}-arm64"
+              docker manifest push "$DESTINATION"
+              docker buildx imagetools create \
+                --tag "danonline/autopulse:${IMAGE_TAG}${FEATURE_SUFFIX}" \
+                "$DESTINATION"
+            done
+          done

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -12,72 +12,73 @@ concurrency:
   group: continuous-delivery-${{ github.ref }}
   cancel-in-progress: ${{ github.ref == 'refs/heads/main' }}
 
-env:
-  CARGO_INCREMENTAL: 0
-  CARGO_NET_GIT_FETCH_WITH_CLI: true
-  CARGO_NET_RETRY: 10
-  CARGO_TERM_COLOR: always
-  RUST_BACKTRACE: 1
-  RUSTFLAGS: -D warnings
-  RUSTUP_MAX_RETRIES: 10
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: sccache
-
 defaults:
   run:
     shell: bash
 
 jobs:
-  upload-assets:
+  linux:
     name: ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - target: aarch64-unknown-linux-gnu
-            os: ubuntu-22.04-arm
           - target: aarch64-unknown-linux-musl
             os: ubuntu-22.04-arm
-          # - target: aarch64-apple-darwin
-          #   os: macos-12
-          # - target: aarch64-pc-windows-msvc
-          #   os: windows-2022
-          - target: x86_64-unknown-linux-gnu
-            os: ubuntu-22.04
           - target: x86_64-unknown-linux-musl
             os: ubuntu-22.04
-
-          - target: x86_64-pc-windows-msvc
-            os: windows-2025
-          # - target: x86_64-apple-darwin
-          #   os: macos-latest
-          # - target: x86_64-pc-windows-msvc
-          #   os: windows-2022
-          # - target: x86_64-unknown-freebsd
-          #   os: ubuntu-22.04
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
-      # - name: Install dependencies on Linux
-      #   if: contains(matrix.os, 'freebsd')
-      #   run: |
-      #     sudo apt-get update
-      #     sudo apt-get install -y libpq-dev libsqlite3-dev
+      - uses: ./.github/actions/setup-nix
+        with:
+          cache-name: release-static
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # - name: Install dependencies on macOS
-      #   if: startsWith(matrix.os, 'macos')
-      #   run: |
-      #     brew update
-      #     brew install libpq sqlite3
+      - name: Build and test portable Linux binary
+        run: |
+          system=$(nix eval --impure --raw --expr builtins.currentSystem)
+          nix build --no-update-lock-file --print-build-logs --no-link \
+            ".#checks.$system.test-static" \
+            ".#checks.$system.doctest-static"
+          nix build --no-update-lock-file --print-build-logs .#static
+          result/bin/autopulse --version
 
-      # - name: Install dependencies on Windows
-      #   if: startsWith(matrix.os, 'windows')
-      #   run: |
-      #     choco install postgresql libsqlite3
+      - name: Package binary
+        env:
+          TARGET: ${{ matrix.target }}
+        run: tar -czf "autopulse-$TARGET.tar.gz" -C result/bin autopulse
+
+      - name: Upload release asset
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          TARGET: ${{ matrix.target }}
+        run: gh release upload "$RELEASE_TAG" "autopulse-$TARGET.tar.gz" --clobber --repo "$GITHUB_REPOSITORY"
+
+  windows:
+    name: x86_64-pc-windows-msvc
+    runs-on: windows-2025
+    timeout-minutes: 60
+    env:
+      CARGO_INCREMENTAL: 0
+      CARGO_NET_GIT_FETCH_WITH_CLI: true
+      CARGO_NET_RETRY: 10
+      CARGO_TERM_COLOR: always
+      RUST_BACKTRACE: 1
+      RUSTFLAGS: -D warnings
+      RUSTUP_MAX_RETRIES: 10
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: sccache
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.11
@@ -90,55 +91,29 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-release-${{ matrix.target }}-full-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-release-x86_64-pc-windows-msvc-full-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-release-${{ matrix.target }}-full-
+            ${{ runner.os }}-cargo-release-x86_64-pc-windows-msvc-full-
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: ${{ matrix.target }}
+          targets: x86_64-pc-windows-msvc
           components: rustfmt,clippy
 
       - uses: taiki-e/setup-cross-toolchain-action@12b7ad4acfa95a1476779d6c06699b96ec1691f8 # v1
         with:
-          target: ${{ matrix.target }}
+          target: x86_64-pc-windows-msvc
 
-      # - uses: taiki-e/install-action@cross
-      #   if: contains(matrix.target, '-musl')
-
-      # - run: echo "RUSTFLAGS=${RUSTFLAGS} -C target-feature=+crt-static" >> "${GITHUB_ENV}"
-      #   if: endsWith(matrix.target, 'windows-msvc')
-
-      # - run: |
-      #     echo "VCPKG_ROOT=$VCPKG_INSTALLATION_ROOT" >> $GITHUB_ENV
-      #     vcpkg install openssl:x64-windows-static-md
-      #   if: startsWith(matrix.os, 'windows')
-
-      - run : |
-          sudo apt update -y && \
-          sudo apt install -y libssl-dev libpq-dev libsqlite3-dev
-        if: startsWith(matrix.os, 'ubuntu') && !contains(matrix.target, '-musl')
-
-      - name: Use Strawberry Perl for OpenSSL build (Windows)
-        if: runner.os == 'Windows'
-        run: echo "OPENSSL_SRC_PERL=C:/Strawberry/perl/bin/perl" >> $GITHUB_ENV
-
-      # SQLite and PostgreSQL installations removed - vendored feature uses
-      # pq-sys/bundled and libsqlite3-sys/bundled which compile from source
-
-      # - run : |
-      #     brew update
-      #     brew install postgresql@14
-      #     HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install sqlite
-      #   if: startsWith(matrix.os, 'macos')
+      - name: Use Strawberry Perl for OpenSSL build
+        run: echo "OPENSSL_SRC_PERL=C:/Strawberry/perl/bin/perl" >> "$GITHUB_ENV"
 
       - uses: taiki-e/upload-rust-binary-action@9db2ba52f2d913fae376c843748c9d2c2ac2c9ba # main
         with:
           bin: autopulse
-          target: ${{ matrix.target }}
+          target: x86_64-pc-windows-msvc
           tar: all
           zip: windows
-          features: ${{ (contains(matrix.target, '-musl') || startsWith(matrix.os, 'windows')) && 'vendored' || '' }}
+          features: vendored
           token: ${{ secrets.GITHUB_TOKEN }}
           dry-run: ${{ github.event_name != 'release' }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,60 +12,14 @@ jobs:
   server:
     name: Server Build and Check
     runs-on: ubuntu-latest
-    env:
-      SCCACHE_GHA_ENABLED: "true"
-      AUTOPULSE_TEST_POSTGRES_URL: postgres://postgres:postgres@localhost:5432/autopulse_test
-    services:
-      postgres:
-        image: postgres:17
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: autopulse_test
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     steps:
       - name: Checkout Project
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.11
-
-      - uses: rrbutani/use-nix-shell-action@v1
-
-      - name: Cargo Cache
-        uses: actions/cache@v6
+      - uses: ./.github/actions/setup-nix
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          restore-keys: |
-            ${{ runner.os }}-cargo-release-x86_64-unknown-linux-musl-
-          key: ${{ runner.os }}-cargo-release-x86_64-unknown-linux-musl-${{ hashFiles('**/Cargo.lock') }}
+          cache-name: checks
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build
-        run: cargo build --release
-
-      - name: Format Check
-        run: cargo fmt -- --check
-
-      - name: Clippy Check
-        run: cargo clippy --release --workspace -- -D warnings
-
-      - name: Test
-        run: cargo nextest run --release --workspace
-
-      - name: PostgreSQL Integration Tests
-        run: cargo test --locked --release -p autopulse-service --features sqlite,postgres --lib postgres_ -- --ignored --test-threads=1
-
-      - name: Backend Feature Checks
-        run: |
-          cargo check --locked -p autopulse-database --no-default-features --features sqlite
-          cargo check --locked -p autopulse-database --no-default-features --features postgres
+      - name: Build, format, lint, and test
+        run: nix flake check --no-update-lock-file --print-build-logs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,9 +13,6 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    env:
-      SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: sccache
     permissions:
       contents: read
       deployments: write
@@ -23,34 +20,15 @@ jobs:
       - name: Checkout Project
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - name: Stable Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.11
-
-      - name: Cargo Cache
-        uses: actions/cache@v6
+      - uses: ./.github/actions/setup-nix
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-docs-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Clean docs folder
-        run: cargo clean --doc
+          cache-name: docs
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build docs
-        run: cargo doc --no-deps --workspace --release
-
-      - name: Add redirect
         run: |
-          echo '<meta http-equiv="refresh" content="0;url=/autopulse/index.html">' > target/doc/index.html
-
-      - name: Remove lock file
-        run: rm target/doc/.lock
+          nix build --no-update-lock-file --print-build-logs .#docs
+          cp -rL result/share/doc site
 
       - name: Publish to Cloudflare Pages
         uses: dan-online/pages-action@main
@@ -58,9 +36,6 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           projectName: autopulse
-          directory: target/doc
+          directory: site
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
           productionBranch: main
-      
-      - name: Clean docs folder
-        run: cargo clean --doc

--- a/crates/database/src/conn.rs
+++ b/crates/database/src/conn.rs
@@ -89,25 +89,23 @@ pub struct AcquireHook {
 
 impl diesel::r2d2::CustomizeConnection<AnyConnection, diesel::r2d2::Error> for AcquireHook {
     fn on_acquire(&self, conn: &mut AnyConnection) -> Result<(), diesel::r2d2::Error> {
-        (|| {
-            match conn {
-                #[cfg(feature = "sqlite")]
-                AnyConnection::Sqlite(ref mut conn) => {
-                    conn.batch_execute("PRAGMA busy_timeout = 5000")?;
-                    conn.batch_execute("PRAGMA synchronous = NORMAL;")?;
-                    conn.batch_execute("PRAGMA wal_autocheckpoint = 1000;")?;
-                    conn.batch_execute("PRAGMA foreign_keys = ON;")?;
+        match conn {
+            #[cfg(feature = "sqlite")]
+            AnyConnection::Sqlite(ref mut conn) => (|| {
+                conn.batch_execute("PRAGMA busy_timeout = 5000")?;
+                conn.batch_execute("PRAGMA synchronous = NORMAL;")?;
+                conn.batch_execute("PRAGMA wal_autocheckpoint = 1000;")?;
+                conn.batch_execute("PRAGMA foreign_keys = ON;")?;
 
-                    if self.setup {
-                        conn.batch_execute("PRAGMA journal_mode = WAL;")?;
-                    }
+                if self.setup {
+                    conn.batch_execute("PRAGMA journal_mode = WAL;")?;
                 }
-                #[cfg(feature = "postgres")]
-                AnyConnection::Postgresql(_) => {}
-            }
-            Ok(())
-        })()
-        .map_err(diesel::r2d2::Error::QueryError)
+                Ok(())
+            })()
+            .map_err(diesel::r2d2::Error::QueryError),
+            #[cfg(feature = "postgres")]
+            AnyConnection::Postgresql(_) => Ok(()),
+        }
     }
 }
 

--- a/crates/server/src/build.rs
+++ b/crates/server/src/build.rs
@@ -1,17 +1,22 @@
 use std::{
-    fs,
+    env, fs,
     hash::{Hash, Hasher},
     path::Path,
     process::Command,
 };
 
 fn main() {
-    let git_hash = Command::new("git")
-        .args(["describe", "--always", "--tags"])
-        .output()
+    println!("cargo:rerun-if-env-changed=GIT_REVISION");
+    let git_hash = env::var("GIT_REVISION")
         .ok()
-        .filter(|o| o.status.success())
-        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .or_else(|| {
+            Command::new("git")
+                .args(["describe", "--always", "--tags"])
+                .output()
+                .ok()
+                .filter(|o| o.status.success())
+                .and_then(|o| String::from_utf8(o.stdout).ok())
+        })
         .unwrap_or_else(|| "unknown".to_string());
 
     println!("cargo:rustc-env=GIT_REVISION={}", git_hash.trim());

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1788465171,
+        "narHash": "sha256-Y1/TTVXjYXGF068IThQH9fPSZ0SIE74PABlUxnWTUH0=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "eb35abda9f232cc6610b1d1e3200d15c49b7ac54",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -36,6 +51,7 @@
     },
     "root": {
       "inputs": {
+        "crane": "crane",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"

--- a/flake.nix
+++ b/flake.nix
@@ -6,6 +6,8 @@
     rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
 
     flake-utils.url = "github:numtide/flake-utils";
+
+    crane.url = "github:ipetkov/crane";
   };
 
   outputs =
@@ -14,6 +16,7 @@
       nixpkgs,
       rust-overlay,
       flake-utils,
+      crane,
       ...
     }:
     flake-utils.lib.eachDefaultSystem (
@@ -27,6 +30,15 @@
         llvmPackages = pkgs.llvmPackages;
 
         rust = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+
+        build = import ./nix/build.nix {
+          inherit
+            self
+            pkgs
+            rust
+            crane
+            ;
+        };
 
         formatterPackage = pkgs.nixfmt-tree;
 
@@ -49,6 +61,9 @@
       in
       {
         formatter = formatterPackage;
+
+        packages = lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux build.packages;
+        checks = lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux build.checks;
 
         devShells.default = pkgs.mkShell {
           packages = [

--- a/nix/build.nix
+++ b/nix/build.nix
@@ -1,0 +1,271 @@
+{
+  self,
+  pkgs,
+  rust,
+  crane,
+}:
+let
+  inherit (pkgs) lib;
+  version = (builtins.fromTOML (builtins.readFile ../Cargo.toml)).workspace.package.version;
+  src = lib.fileset.toSource {
+    root = ../.;
+    fileset = lib.fileset.unions [
+      ../Cargo.toml
+      ../Cargo.lock
+      ../.cargo
+      ../src
+      ../crates
+      ../assets
+      ../README.md
+    ];
+  };
+  craneLib = (crane.mkLib pkgs).overrideToolchain rust;
+  cargoVendorDir = craneLib.vendorCargoDeps { inherit src; };
+  mkBuild =
+    packageSet: databaseFeatures:
+    let
+      static = packageSet.stdenv.hostPlatform.isStatic;
+      toolchainFor =
+        p:
+        (p.rust-bin.fromRustupToolchainFile ../rust-toolchain.toml).override {
+          targets = lib.optional static packageSet.stdenv.hostPlatform.rust.rustcTarget;
+        };
+      toolchain = toolchainFor pkgs;
+      builder = (crane.mkLib packageSet).overrideToolchain toolchainFor;
+      libpq =
+        if static then
+          packageSet.libpq.overrideAttrs (old: {
+            # Nix puts the archives in dev; pkg-config needs that path to bundle them together.
+            postFixup = (old.postFixup or "") + ''
+              substituteInPlace "$dev/lib/pkgconfig/libpq.pc" \
+                --replace-fail 'libdir=''${exec_prefix}/lib' "libdir=$dev/lib"
+            '';
+          })
+        else
+          packageSet.libpq;
+      commonArgs = {
+        inherit src version cargoVendorDir;
+        pname = "autopulse";
+        strictDeps = true;
+        cargoExtraArgs = "--locked --workspace --no-default-features --features ${lib.concatStringsSep "," databaseFeatures}";
+        nativeBuildInputs = [
+          pkgs.pkg-config
+          pkgs.cmake
+        ];
+        buildInputs =
+          lib.optionals (lib.elem "postgres" databaseFeatures) [ libpq ]
+          ++ lib.optionals (lib.elem "sqlite" databaseFeatures) [ packageSet.sqlite ];
+        env = {
+          # Embedded standard-library source paths must not retain the toolchain.
+          RUSTFLAGS = "--remap-path-prefix=${toolchain}=/rustc";
+        }
+        // lib.optionalAttrs static {
+          CARGO_BUILD_TARGET = packageSet.stdenv.hostPlatform.rust.rustcTarget;
+          # Include libpq's private dependencies when linking its static archive.
+          PKG_CONFIG_ALL_STATIC = "1";
+          OPENSSL_NO_VENDOR = "1";
+        };
+      };
+      cargoArtifacts = builder.buildDepsOnly commonArgs;
+      appArgs = commonArgs // {
+        inherit cargoArtifacts;
+        env = commonArgs.env // {
+          GIT_REVISION = self.shortRev or self.dirtyShortRev or "unknown";
+        };
+      };
+      testArgs = appArgs // {
+        env = appArgs.env // {
+          SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+        };
+      };
+    in
+    {
+      package = builder.buildPackage (
+        appArgs
+        // {
+          # Nextest and doctests are separate, cacheable checks.
+          doCheck = false;
+          disallowedReferences = [ toolchain ];
+        }
+        // lib.optionalAttrs static {
+          postFixup = ''
+            ${pkgs.binutils}/bin/readelf --program-headers "$out/bin/autopulse" > headers
+            ${pkgs.binutils}/bin/readelf --dynamic "$out/bin/autopulse" > dynamic
+            ! grep -q INTERP headers
+            ! grep -q NEEDED dynamic
+          '';
+        }
+      );
+      nextest = builder.cargoNextest (
+        testArgs
+        // {
+          doInstallCargoArtifacts = false;
+        }
+      );
+      doctests = builder.cargoTest (
+        testArgs
+        // {
+          cargoTestExtraArgs = "--doc";
+          doInstallCargoArtifacts = false;
+        }
+      );
+      clippy = builder.cargoClippy (
+        appArgs
+        // {
+          cargoClippyExtraArgs = "-- --deny warnings";
+          doInstallCargoArtifacts = false;
+        }
+      );
+      database = builder.mkCargoDerivation (
+        appArgs
+        // {
+          pnameSuffix = "-database-check";
+          buildPhaseCargoCommand = "cargoWithProfile check --locked -p autopulse-database --no-default-features --features ${lib.concatStringsSep "," databaseFeatures}";
+          doCheck = false;
+          doInstallCargoArtifacts = false;
+        }
+      );
+      postgresTest = builder.cargoTest (
+        testArgs
+        // {
+          cargoExtraArgs = "--locked -p autopulse-service --no-default-features --features ${lib.concatStringsSep "," databaseFeatures}";
+          cargoTestExtraArgs = "--lib postgres_ -- --ignored --test-threads=1";
+          doInstallCargoArtifacts = false;
+          nativeBuildInputs = commonArgs.nativeBuildInputs ++ [ pkgs.postgresql_17 ];
+          preCheck = ''
+            export PGDATA="$TMPDIR/postgres"
+            export PGHOST="$TMPDIR"
+            export PGUSER=postgres
+            initdb --username="$PGUSER" --auth=trust --encoding=UTF8 --no-locale
+            pg_ctl -l "$TMPDIR/postgres.log" -o "-k $PGHOST -c listen_addresses=" -w start
+            stopPostgres() { pg_ctl -m fast -w stop; }
+            exitHooks+=(stopPostgres)
+            failureHooks+=(stopPostgres)
+            createdb autopulse_test
+            export AUTOPULSE_TEST_POSTGRES_URL="postgresql:///autopulse_test?host=$PGHOST&user=$PGUSER"
+          '';
+        }
+      );
+      docs = builder.cargoDoc (
+        appArgs
+        // {
+          postInstall = ''
+            echo '<meta http-equiv="refresh" content="0;url=/autopulse/index.html">' > "$out/share/doc/index.html"
+            rm -f "$out/share/doc/.lock"
+          '';
+        }
+      );
+    };
+  variants = {
+    full = mkBuild pkgs [
+      "postgres"
+      "sqlite"
+    ];
+    postgres = mkBuild pkgs [ "postgres" ];
+    sqlite = mkBuild pkgs [ "sqlite" ];
+  };
+  staticBuild = mkBuild pkgs.pkgsStatic [
+    "postgres"
+    "sqlite"
+  ];
+  mkImage =
+    variant: package:
+    pkgs.dockerTools.buildLayeredImage {
+      name = "autopulse";
+      tag = variant;
+      contents = [
+        pkgs.dockerTools.binSh
+        pkgs.dockerTools.usrBinEnv
+        pkgs.dockerTools.caCertificates
+      ];
+      extraCommands = ''
+        mkdir -p bin etc usr/share app config data tmp
+        ln -s ${package}/bin/autopulse bin/autopulse
+        ln -s ${pkgs.tzdata}/share/zoneinfo usr/share/zoneinfo
+        cp ${../docker-entrypoint.sh} docker-entrypoint.sh
+        chmod 555 docker-entrypoint.sh
+        echo 'root:x:0:0:root:/root:/bin/sh' > etc/passwd
+        echo 'autopulse:x:1000:1000::/config:/bin/sh' >> etc/passwd
+        echo 'root:x:0:' > etc/group
+        echo 'autopulse:x:1000:' >> etc/group
+      '';
+      fakeRootCommands = ''
+        chown 1000:1000 app config data
+        chmod 1777 tmp
+      '';
+      config = {
+        WorkingDir = "/app";
+        Entrypoint = [
+          "${pkgs.tini}/bin/tini"
+          "--"
+          "/docker-entrypoint.sh"
+        ];
+        Cmd = [ "/bin/autopulse" ];
+        Env = [
+          "PATH=/bin:/usr/bin:${
+            lib.makeBinPath [
+              pkgs.coreutils
+              pkgs.shadow
+              pkgs.su-exec
+              pkgs.wget
+              pkgs.curl
+            ]
+          }"
+          "TZDIR=/usr/share/zoneinfo"
+          "SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt"
+        ];
+        Healthcheck = {
+          Test = [
+            "CMD-SHELL"
+            "wget -q -O /dev/null --tries=1 http://127.0.0.1:\${AUTOPULSE__APP__PORT:-2875}/stats || exit 1"
+          ];
+          Interval = 10000000000;
+          Timeout = 5000000000;
+          StartPeriod = 5000000000;
+          Retries = 3;
+        };
+        Labels = {
+          "org.opencontainers.image.title" = "autopulse";
+          "org.opencontainers.image.source" = "https://github.com/dan-online/autopulse";
+          "org.opencontainers.image.version" = package.version;
+          "org.opencontainers.image.revision" = self.rev or self.dirtyRev or "unknown";
+        };
+      };
+    };
+in
+{
+  packages =
+    lib.mapAttrs (_: build: build.package) variants
+    // lib.mapAttrs' (
+      name: build: lib.nameValuePair "image-${name}" (mkImage name build.package)
+    ) variants
+    // {
+      default = variants.full.package;
+      image = mkImage "full" variants.full.package;
+      docs = variants.full.docs;
+      static = staticBuild.package;
+    };
+  checks =
+    lib.foldlAttrs
+      (
+        acc: name: build:
+        acc
+        // {
+          "build-${name}" = build.package;
+          "clippy-${name}" = build.clippy;
+          "test-${name}" = build.nextest;
+          "doctest-${name}" = build.doctests;
+        }
+      )
+      {
+        fmt = craneLib.cargoFmt { inherit src; };
+        docs = variants.full.docs;
+        postgres-integration = variants.full.postgresTest;
+        database-postgres = variants.postgres.database;
+        database-sqlite = variants.sqlite.database;
+        build-static = staticBuild.package;
+        test-static = staticBuild.nextest;
+        doctest-static = staticBuild.doctests;
+      }
+      variants;
+}


### PR DESCRIPTION
# Description

Moves Linux builds, checks, docs and Docker images to Nix with shared `crane` build artifacts.

Drops the separate `gnu` release assets in favour of static `musl` binaries.

## Type of change

- [ ] Bug (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [x] Breaking change (removes the `*-linux-gnu` release assets)
- [ ] Documentation (addition or change to documentation)
